### PR TITLE
Add Mistral AI as a sixth AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Mistral AI as a new AI provider** - added Mistral (OpenAI-compatible API) as a sixth AI provider for both label recognition and the sommelier chat. The default model is `pixtral-large-latest` for vision; regular Mistral text models work for chat. Resolves #13.
+
 ## 1.9.2
 
 - **Fix Vivino search** - Vivino redirected all search pages to a client-rendered explore page, breaking wine lookups entirely. The search now calls Vivino's internal JSON API directly, restoring reliable results across all wine regions.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A sleek, modern wine cellar tracker. Run it as a **Home Assistant add-on** or as
 
 ### AI & Integrations
 
-- **AI label recognition** - snap a label photo and let AI fill in all fields, including maturity phases, taste profile and food pairings (5 providers: Anthropic, OpenAI, OpenRouter, Ollama, MiniMax)
+- **AI label recognition** - snap a label photo and let AI fill in all fields, including maturity phases, taste profile and food pairings (6 providers: Anthropic, OpenAI, OpenRouter, Ollama, MiniMax, Mistral)
 - **Vivino wine search** - search by name, see ratings, region & price, and import directly — with a regional fallback chain so country-specific wines (e.g. Australian labels) actually show up
 - **Vivino ID management** - view, edit & test Vivino wine links directly in the edit modal
 - **Reload missing data** - re-analyze wines with incomplete fields via AI or Vivino
@@ -177,7 +177,7 @@ docker-compose up -d
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AI_PROVIDER` | `none` | AI provider: `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax` |
+| `AI_PROVIDER` | `none` | AI provider: `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax`, `mistral` |
 
 **Anthropic (Claude):**
 
@@ -218,6 +218,15 @@ docker-compose up -d
 
 > **Note:** `MiniMax-Text-01` is MiniMax's current vision-capable model — despite the name it accepts image input. The older `MiniMax-VL-01` name is no longer accepted by the API.
 
+**Mistral:**
+
+| Variable | Default |
+|----------|---------|
+| `MISTRAL_API_KEY` | _(empty)_ |
+| `MISTRAL_MODEL` | `pixtral-large-latest` |
+
+> **Note:** For label recognition (vision) use a Pixtral model (`pixtral-large-latest`, `pixtral-12b-latest`). Other Mistral models like `mistral-large-latest` work for the sommelier chat but cannot read labels.
+
 ### Updating
 
 ```bash
@@ -246,7 +255,7 @@ The AI feature lets you snap a photo of a wine label and automatically fills in 
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `ai_provider` | dropdown | `none` | AI provider: `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax` |
+| `ai_provider` | dropdown | `none` | AI provider: `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax`, `mistral` |
 | `anthropic_api_key` | string | _(empty)_ | API key for Anthropic (Claude) |
 | `anthropic_model` | string | `claude-opus-4-6` | Anthropic model name |
 | `openai_api_key` | string | _(empty)_ | API key for OpenAI |
@@ -257,6 +266,8 @@ The AI feature lets you snap a photo of a wine label and automatically fills in 
 | `ollama_model` | string | `llava` | Ollama vision model name |
 | `minimax_api_key` | string | _(empty)_ | API key for MiniMax |
 | `minimax_model` | string | `MiniMax-Text-01` | MiniMax model name (vision-capable despite the name) |
+| `mistral_api_key` | string | _(empty)_ | API key for Mistral AI |
+| `mistral_model` | string | `pixtral-large-latest` | Mistral model name (use a Pixtral model for label recognition) |
 
 **Provider notes:**
 - **Anthropic** - uses the Claude API directly. Requires an API key from [console.anthropic.com](https://console.anthropic.com)
@@ -264,6 +275,7 @@ The AI feature lets you snap a photo of a wine label and automatically fills in 
 - **OpenRouter** - a unified API that routes to many models. Requires an API key from [openrouter.ai](https://openrouter.ai). You can choose any vision-capable model.
 - **Ollama** - runs fully local, no API key needed. Install [Ollama](https://ollama.com) and pull a vision model (e.g. `llava`). Set the host to your Ollama server address.
 - **MiniMax** - OpenAI-compatible API from [minimaxi.chat](https://api.minimaxi.chat). The default model `MiniMax-Text-01` supports vision input despite the name; the older `MiniMax-VL-01` name is no longer accepted by the API.
+- **Mistral** - OpenAI-compatible API from [mistral.ai](https://console.mistral.ai). For label recognition use a Pixtral model (e.g. `pixtral-large-latest`); regular Mistral text models work for the sommelier chat but cannot read labels. A free Experiment plan is available for some regions ([details](https://help.mistral.ai/en/articles/455206)).
 
 **Estimated token cost per wine analysis** (~2,500 tokens):
 

--- a/wine-tracker/CHANGELOG.md
+++ b/wine-tracker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Mistral AI as a new AI provider** - added Mistral (OpenAI-compatible API) as a sixth AI provider for both label recognition and the sommelier chat. The default model is `pixtral-large-latest` for vision; regular Mistral text models work for chat. Resolves #13.
+
 ## 1.9.2
 
 - **Fix Vivino search** - Vivino redirected all search pages to a client-rendered explore page, breaking wine lookups entirely. The search now calls Vivino's internal JSON API directly, restoring reliable results across all wine regions.

--- a/wine-tracker/DOCS.md
+++ b/wine-tracker/DOCS.md
@@ -25,7 +25,7 @@ A sleek, modern wine cellar tracker running directly in your Home Assistant side
 ## Features
 
 - **Wine cards** with photo, vintage, type, region, grape variety, rating & notes
-- **AI wine label recognition** — snap a label photo and let AI fill in all fields, including maturity phases, taste profile and food pairings (Anthropic, OpenAI, OpenRouter, Ollama, MiniMax)
+- **AI wine label recognition** — snap a label photo and let AI fill in all fields, including maturity phases, taste profile and food pairings (Anthropic, OpenAI, OpenRouter, Ollama, MiniMax, Mistral)
 - **AI sommelier chat with full cellar CRUD** — ask questions about your cellar, upload wine label photos, and add / edit / delete wines directly from the conversation; persistent sessions
 - **Vivino wine search** — search by name, see ratings, region & price, and import directly; regional fallback chain surfaces country-specific wines (e.g. Australian labels)
 - **Vivino ID management** — view, edit & test Vivino wine links directly in the edit modal
@@ -65,7 +65,7 @@ Pick one AI provider and configure its API key and model. The AI is used for lab
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `ai_provider` | `none` | `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax` |
+| `ai_provider` | `none` | `none`, `anthropic`, `openai`, `openrouter`, `ollama`, `minimax`, `mistral` |
 | `anthropic_api_key` | _(empty)_ | Claude API key from [console.anthropic.com](https://console.anthropic.com) |
 | `anthropic_model` | `claude-opus-4-6` | Anthropic model identifier |
 | `openai_api_key` | _(empty)_ | OpenAI API key from [platform.openai.com](https://platform.openai.com) |
@@ -76,6 +76,8 @@ Pick one AI provider and configure its API key and model. The AI is used for lab
 | `ollama_model` | `llava` | Local Ollama vision model |
 | `minimax_api_key` | _(empty)_ | MiniMax API key from [api.minimaxi.chat](https://api.minimaxi.chat) |
 | `minimax_model` | `MiniMax-Text-01` | MiniMax model (vision-capable despite the "Text" name) |
+| `mistral_api_key` | _(empty)_ | Mistral API key from [console.mistral.ai](https://console.mistral.ai) |
+| `mistral_model` | `pixtral-large-latest` | Mistral model (use a Pixtral model for label recognition) |
 
 > **Tip:** Ollama runs fully local and requires no API key. Pull a vision model (`ollama pull llava`) and point `ollama_host` at your Ollama server.
 

--- a/wine-tracker/README.md
+++ b/wine-tracker/README.md
@@ -19,7 +19,7 @@ Vivino to import wines with ratings and pricing.
 
 **Key features:**
 
-- 📸 AI wine label recognition with 5 providers (Anthropic, OpenAI, OpenRouter, Ollama, MiniMax)
+- 📸 AI wine label recognition with 6 providers (Anthropic, OpenAI, OpenRouter, Ollama, MiniMax, Mistral)
 - 🔎 Vivino wine search with direct import and a regional fallback chain for country-specific labels
 - 🌍 Interactive 3D globe showing your wine regions
 - 📊 Statistics with donut charts, stock history chart, total liters & value overview

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -67,6 +67,8 @@ def load_options():
         "ollama_model": "llava",
         "minimax_api_key": "",
         "minimax_model": "MiniMax-Text-01",
+        "mistral_api_key": "",
+        "mistral_model": "pixtral-large-latest",
     }
     try:
         with open(OPTIONS_PATH, "r") as f:
@@ -90,6 +92,8 @@ def load_options():
         "OLLAMA_MODEL": "ollama_model",
         "MINIMAX_API_KEY": "minimax_api_key",
         "MINIMAX_MODEL": "minimax_model",
+        "MISTRAL_API_KEY": "mistral_api_key",
+        "MISTRAL_MODEL": "mistral_model",
     }
     for env_key, opt_key in env_map.items():
         val = os.environ.get(env_key)
@@ -114,6 +118,8 @@ def _is_ai_configured(opts):
         return bool(opts.get("ollama_host", "").strip())
     elif provider == "minimax":
         return bool(opts.get("minimax_api_key", "").strip())
+    elif provider == "mistral":
+        return bool(opts.get("mistral_api_key", "").strip())
     return False
 
 
@@ -1531,6 +1537,24 @@ def _call_minimax(image_b64, media_type, prompt, opts):
     return response.choices[0].message.content
 
 
+def _call_mistral(image_b64, media_type, prompt, opts):
+    """Call Mistral AI API (OpenAI-compatible, vision via Pixtral models)."""
+    from openai import OpenAI
+    api_key = opts.get("mistral_api_key", "").strip()
+    model = opts.get("mistral_model", "pixtral-large-latest").strip() or "pixtral-large-latest"
+    client = OpenAI(api_key=api_key, base_url="https://api.mistral.ai/v1")
+    content = []
+    if image_b64:
+        content.append({"type": "image_url", "image_url": {"url": f"data:{media_type};base64,{image_b64}"}})
+    content.append({"type": "text", "text": prompt})
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": content}],
+        max_tokens=1024,
+    )
+    return response.choices[0].message.content
+
+
 # ── AI Chat Functions ─────────────────────────────────────────────────────────
 
 def _call_chat_anthropic(messages, system_prompt, opts, image_b64=None, media_type=None):
@@ -1644,6 +1668,28 @@ def _call_chat_minimax(messages, system_prompt, opts, image_b64=None, media_type
     return response.choices[0].message.content
 
 
+def _call_chat_mistral(messages, system_prompt, opts, image_b64=None, media_type=None):
+    """Chat via Mistral AI (OpenAI-compatible, multi-turn, with optional image)."""
+    from openai import OpenAI
+    api_key = opts.get("mistral_api_key", "").strip()
+    model = opts.get("mistral_model", "pixtral-large-latest").strip() or "pixtral-large-latest"
+    client = OpenAI(api_key=api_key, base_url="https://api.mistral.ai/v1")
+    if image_b64 and messages:
+        last = messages[-1]
+        if last["role"] == "user":
+            messages = messages[:-1] + [{"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": f"data:{media_type};base64,{image_b64}"}},
+                {"type": "text", "text": last["content"]},
+            ]}]
+    full_messages = [{"role": "system", "content": system_prompt}] + messages
+    response = client.chat.completions.create(
+        model=model,
+        messages=full_messages,
+        max_tokens=2048,
+    )
+    return response.choices[0].message.content
+
+
 def _call_chat(provider, messages, system_prompt, opts, image_b64=None, media_type=None):
     """Dispatch chat to the configured AI provider."""
     dispatch = {
@@ -1652,6 +1698,7 @@ def _call_chat(provider, messages, system_prompt, opts, image_b64=None, media_ty
         "openrouter": _call_chat_openrouter,
         "ollama": _call_chat_ollama,
         "minimax": _call_chat_minimax,
+        "mistral": _call_chat_mistral,
     }
     fn = dispatch.get(provider)
     if not fn:
@@ -1780,6 +1827,7 @@ Rules:
             "openrouter": _call_openrouter,
             "ollama": _call_ollama,
             "minimax": _call_minimax,
+            "mistral": _call_mistral,
         }
         call_fn = dispatch.get(provider)
         if not call_fn:
@@ -2106,6 +2154,7 @@ def _analyze_wine_from_context(opts, image_b64, media_type, wine_context):
         "openrouter": _call_openrouter,
         "ollama": _call_ollama,
         "minimax": _call_minimax,
+        "mistral": _call_mistral,
     }
     call_fn = dispatch.get(provider)
     if not call_fn:

--- a/wine-tracker/config.yaml
+++ b/wine-tracker/config.yaml
@@ -34,10 +34,12 @@ options:
   ollama_model: "llava"
   minimax_api_key: ""
   minimax_model: "MiniMax-Text-01"
+  mistral_api_key: ""
+  mistral_model: "pixtral-large-latest"
 schema:
   currency: str
   language: str
-  ai_provider: list(none|anthropic|openai|openrouter|ollama|minimax)
+  ai_provider: list(none|anthropic|openai|openrouter|ollama|minimax|mistral)
   anthropic_api_key: str?
   anthropic_model: str?
   openai_api_key: str?
@@ -48,5 +50,7 @@ schema:
   ollama_model: str?
   minimax_api_key: str?
   minimax_model: str?
+  mistral_api_key: str?
+  mistral_model: str?
 map:
   - share:rw

--- a/wine-tracker/tests/test_api.py
+++ b/wine-tracker/tests/test_api.py
@@ -161,6 +161,41 @@ class TestAnalyzeWine:
         assert data["fields"]["name"] == "Penfolds Grange"
         mock_call.assert_called_once()
 
+    @patch("app._call_mistral")
+    @patch("app.load_options")
+    def test_mistral_provider(self, mock_opts, mock_call, client):
+        """Should use Mistral when configured."""
+        mock_opts.return_value = {
+            **wine_app.HA_OPTIONS,
+            "ai_provider": "mistral",
+            "mistral_api_key": "ms-test-key",
+            "mistral_model": "pixtral-large-latest",
+        }
+        mock_call.return_value = json.dumps({
+            "name": "Château Margaux",
+            "wine_type": "Rotwein",
+            "vintage": 2015,
+            "region": "Bordeaux",
+            "grape": "Cabernet Sauvignon",
+            "price": None,
+            "notes": "",
+            "drink_from": None,
+            "drink_until": None,
+            "bottle_format": None,
+        })
+
+        fake_image = (io.BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100), "test.jpg")
+        resp = client.post(
+            "/api/analyze-wine",
+            data={"image": fake_image},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["ok"] is True
+        assert data["fields"]["name"] == "Château Margaux"
+        mock_call.assert_called_once()
+
     @patch("app._call_anthropic")
     @patch("app.load_options")
     def test_ai_json_parse_error(self, mock_opts, mock_call, client):
@@ -622,6 +657,25 @@ class TestWineChat:
         assert data["ok"] is True
         provider_arg = mock_chat.call_args[0][0]
         assert provider_arg == "minimax"
+
+    @patch("app._call_chat")
+    @patch("app.load_options")
+    def test_chat_mistral_provider(self, mock_opts, mock_chat, client):
+        """Should pass 'mistral' as provider to _call_chat when Mistral is configured."""
+        mock_opts.return_value = {
+            **wine_app.HA_OPTIONS,
+            "ai_provider": "mistral",
+            "mistral_api_key": "ms-test-key",
+            "mistral_model": "pixtral-large-latest",
+        }
+        mock_chat.return_value = "Mistral recommends a Châteauneuf-du-Pape."
+
+        resp = self._post_chat(client, message="Suggest a red wine")
+        data = json.loads(resp.data)
+        assert resp.status_code == 200
+        assert data["ok"] is True
+        provider_arg = mock_chat.call_args[0][0]
+        assert provider_arg == "mistral"
 
     @patch("app._call_chat")
     @patch("app.load_options")


### PR DESCRIPTION
## Summary
- Adds Mistral AI as the sixth AI provider, alongside Anthropic, OpenAI, OpenRouter, Ollama and MiniMax
- Uses Mistral's OpenAI-compatible API at `https://api.mistral.ai/v1`
- Default model `pixtral-large-latest` (vision-capable, required for label recognition); other Mistral text models work for the sommelier chat
- Resolves #13

## Changes
- New `_call_mistral` and `_call_chat_mistral` functions in [`app.py`](wine-tracker/app/app.py)
- Mistral wired into defaults, env mapping (`MISTRAL_API_KEY`, `MISTRAL_MODEL`), `_is_ai_configured`, and the three dispatcher tables
- `config.yaml` options and schema enum extended
- `test_mistral_provider` and `test_chat_mistral_provider` added in [`test_api.py`](wine-tracker/tests/test_api.py)
- README, DOCS and CHANGELOG updated

## Test plan
- [x] `pytest tests/ -v` - all 318 tests pass (including 2 new Mistral tests)
- [x] Manual chat verified against the live Mistral API (`pixtral-large-latest`)
- [x] Manual label scan verified against the live Mistral API (`pixtral-large-latest`)