### PR TITLE
feat: show out-of-stock wines with ribbon badge and persistent setting

### DIFF
--- a/wine-tracker/app/templates/_settings_modal.html
+++ b/wine-tracker/app/templates/_settings_modal.html
@@ -110,6 +110,16 @@
             </label>
           </div>
         </div>
+
+        <div class="settings-row">
+          <div class="settings-row-label">{{ t.settings_show_empty }}</div>
+          <div class="settings-row-control">
+            <label class="toggle-switch">
+              <input type="checkbox" id="showEmptyDefaultToggle" onchange="setShowEmptyDefault(this.checked)">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
       </div>
 
       <!-- Chat (only when AI is configured) -->

--- a/wine-tracker/app/templates/index.html
+++ b/wine-tracker/app/templates/index.html
@@ -424,7 +424,7 @@ function syncTableVisibility() {
 // ── Client-side filter state ─────────────────────────────────────────────────
 var activeType = '';
 var activeDrinkWindow = '';
-var showEmpty = false;
+var showEmpty = localStorage.getItem('wine-show-empty') === '1';
 var _filterTimer = null;
 
 function debouncedFilter() {
@@ -696,6 +696,7 @@ function openModal(id) {
     updateThemeDropdown();
     initChatRecordingToggle();
     initAdvancedFilterDefaultToggle();
+    initShowEmptyDefaultToggle();
   }
 }
 
@@ -707,6 +708,23 @@ function initAdvancedFilterDefaultToggle() {
 function setAdvancedFilterDefault(enabled) {
   if (enabled) localStorage.setItem('wine-advanced-filter-default', '1');
   else localStorage.removeItem('wine-advanced-filter-default');
+}
+
+function initShowEmptyDefaultToggle() {
+  var cb = document.getElementById('showEmptyDefaultToggle');
+  if (cb) cb.checked = localStorage.getItem('wine-show-empty') === '1';
+}
+
+function setShowEmptyDefault(enabled) {
+  if (enabled) localStorage.setItem('wine-show-empty', '1');
+  else localStorage.removeItem('wine-show-empty');
+  showEmpty = enabled;
+  applyFilters();
+  // Sync the quick-toggle button label/icon
+  var icon = document.querySelector('#toggleEmptyBtn .mdi');
+  var label = document.querySelector('#toggleEmptyBtn .toggle-empty-label');
+  if (icon) icon.className = 'mdi ' + (showEmpty ? 'mdi-eye-off-outline' : 'mdi-eye-outline');
+  if (label) label.textContent = showEmpty ? T.toggle_empty_hide : T.toggle_empty_show;
 }
 function closeModal(id) {
   document.getElementById(id).classList.remove('open');
@@ -1381,7 +1399,15 @@ document.getElementById('deleteForm').addEventListener('submit', function(e) {
   history.replaceState(null, '', window.location.pathname + (clean ? '?' + clean : ''));
 })();
 
-// Apply filters on initial load (hides empty bottles when showEmpty is false)
+// Sync quick-toggle button label/icon with persisted showEmpty preference
+(function() {
+  var icon = document.querySelector('#toggleEmptyBtn .mdi');
+  var label = document.querySelector('#toggleEmptyBtn .toggle-empty-label');
+  if (icon) icon.className = 'mdi ' + (showEmpty ? 'mdi-eye-off-outline' : 'mdi-eye-outline');
+  if (label) label.textContent = showEmpty ? T.toggle_empty_hide : T.toggle_empty_show;
+})();
+
+// Apply filters on initial load
 applyFilters();
 
 // Drink window warnings - reusable so it works after AJAX add/edit/duplicate

--- a/wine-tracker/app/translations.py
+++ b/wine-tracker/app/translations.py
@@ -139,7 +139,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Erweiterten Filter als Standard",
     "toggle_empty_hide": "Leere ausblenden",
     "toggle_empty_show": "Leere anzeigen",
-    "ribbon_empty": "Nicht vorrätig",
+    "ribbon_empty": "Leer",
     "settings_show_empty": "Leere Flaschen anzeigen",
     "btn_add_wine": "+ Wein hinzufügen",
 
@@ -493,7 +493,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Use advanced filter as default",
     "toggle_empty_hide": "Hide empty",
     "toggle_empty_show": "Show empty",
-    "ribbon_empty": "Out of Stock",
+    "ribbon_empty": "Empty",
     "settings_show_empty": "Show out-of-stock wines",
     "btn_add_wine": "+ Add wine",
 
@@ -838,7 +838,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Utiliser le filtre avancé par défaut",
     "toggle_empty_hide": "Masquer vides",
     "toggle_empty_show": "Afficher vides",
-    "ribbon_empty": "Rupture de stock",
+    "ribbon_empty": "Vide",
     "settings_show_empty": "Afficher les vins épuisés",
     "btn_add_wine": "+ Ajouter un vin",
 
@@ -1183,7 +1183,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usa filtro avanzato come predefinito",
     "toggle_empty_hide": "Nascondi vuoti",
     "toggle_empty_show": "Mostra vuoti",
-    "ribbon_empty": "Esaurito",
+    "ribbon_empty": "Vuoto",
     "settings_show_empty": "Mostra vini esauriti",
     "btn_add_wine": "+ Aggiungi vino",
 
@@ -1528,7 +1528,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usar filtro avanzado por defecto",
     "toggle_empty_hide": "Ocultar vacíos",
     "toggle_empty_show": "Mostrar vacíos",
-    "ribbon_empty": "Sin existencias",
+    "ribbon_empty": "Agotado",
     "settings_show_empty": "Mostrar vinos agotados",
     "btn_add_wine": "+ Añadir vino",
 
@@ -1873,7 +1873,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usar filtro avançado como padrão",
     "toggle_empty_hide": "Ocultar vazios",
     "toggle_empty_show": "Mostrar vazios",
-    "ribbon_empty": "Sem estoque",
+    "ribbon_empty": "Vazio",
     "settings_show_empty": "Mostrar vinhos sem estoque",
     "btn_add_wine": "+ Adicionar vinho",
 
@@ -2218,7 +2218,7 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Geavanceerd filter als standaard gebruiken",
     "toggle_empty_hide": "Lege verbergen",
     "toggle_empty_show": "Lege tonen",
-    "ribbon_empty": "Niet op voorraad",
+    "ribbon_empty": "Leeg",
     "settings_show_empty": "Toon uitverkochte wijnen",
     "btn_add_wine": "+ Wijn toevoegen",
 

--- a/wine-tracker/app/translations.py
+++ b/wine-tracker/app/translations.py
@@ -139,6 +139,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Erweiterten Filter als Standard",
     "toggle_empty_hide": "Leere ausblenden",
     "toggle_empty_show": "Leere anzeigen",
+    "ribbon_empty": "Nicht vorrätig",
+    "settings_show_empty": "Leere Flaschen anzeigen",
     "btn_add_wine": "+ Wein hinzufügen",
 
     # Wine form
@@ -491,6 +493,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Use advanced filter as default",
     "toggle_empty_hide": "Hide empty",
     "toggle_empty_show": "Show empty",
+    "ribbon_empty": "Out of Stock",
+    "settings_show_empty": "Show out-of-stock wines",
     "btn_add_wine": "+ Add wine",
 
     "modal_add_title": "Add wine",
@@ -834,6 +838,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Utiliser le filtre avancé par défaut",
     "toggle_empty_hide": "Masquer vides",
     "toggle_empty_show": "Afficher vides",
+    "ribbon_empty": "Rupture de stock",
+    "settings_show_empty": "Afficher les vins épuisés",
     "btn_add_wine": "+ Ajouter un vin",
 
     "modal_add_title": "Ajouter un vin",
@@ -1177,6 +1183,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usa filtro avanzato come predefinito",
     "toggle_empty_hide": "Nascondi vuoti",
     "toggle_empty_show": "Mostra vuoti",
+    "ribbon_empty": "Esaurito",
+    "settings_show_empty": "Mostra vini esauriti",
     "btn_add_wine": "+ Aggiungi vino",
 
     "modal_add_title": "Aggiungi vino",
@@ -1520,6 +1528,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usar filtro avanzado por defecto",
     "toggle_empty_hide": "Ocultar vacíos",
     "toggle_empty_show": "Mostrar vacíos",
+    "ribbon_empty": "Sin existencias",
+    "settings_show_empty": "Mostrar vinos agotados",
     "btn_add_wine": "+ Añadir vino",
 
     "modal_add_title": "Añadir vino",
@@ -1863,6 +1873,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Usar filtro avançado como padrão",
     "toggle_empty_hide": "Ocultar vazios",
     "toggle_empty_show": "Mostrar vazios",
+    "ribbon_empty": "Sem estoque",
+    "settings_show_empty": "Mostrar vinhos sem estoque",
     "btn_add_wine": "+ Adicionar vinho",
 
     "modal_add_title": "Adicionar vinho",
@@ -2206,6 +2218,8 @@ TRANSLATIONS = {
     "settings_advanced_filter_default": "Geavanceerd filter als standaard gebruiken",
     "toggle_empty_hide": "Lege verbergen",
     "toggle_empty_show": "Lege tonen",
+    "ribbon_empty": "Niet op voorraad",
+    "settings_show_empty": "Toon uitverkochte wijnen",
     "btn_add_wine": "+ Wijn toevoegen",
 
     "modal_add_title": "Wijn toevoegen",

--- a/wine-tracker/tests/test_helpers.py
+++ b/wine-tracker/tests/test_helpers.py
@@ -300,6 +300,18 @@ class TestViewModalTranslations:
             assert "view_drink_window" in TRANSLATIONS[lang], f"Missing view_drink_window in {lang}"
 
 
+# ── Out-of-stock translations ────────────────────────────────────────────────
+
+class TestOutOfStockTranslations:
+    def test_out_of_stock_keys_in_all_languages(self):
+        """All 7 languages need the out-of-stock ribbon and settings keys, non-empty."""
+        from translations import TRANSLATIONS
+        for lang in TRANSLATIONS:
+            for key in ("ribbon_empty", "settings_show_empty"):
+                assert key in TRANSLATIONS[lang], f"Missing {key} in {lang}"
+                assert TRANSLATIONS[lang][key].strip(), f"Empty {key} in {lang}"
+
+
 # ── parse_user_string / DEV_AUTH ─────────────────────────────────────────────
 
 class TestParseUserString:


### PR DESCRIPTION
## Problem

When a wine reaches zero stock, it currently disappears from the main view — making it easy to forget to restock it. This PR keeps out-of-stock wines visible and clearly labeled.

## Changes

- Out-of-stock wines now display an **"Out of Stock"** ribbon badge (matching the existing wine-type ribbon style), translated across all 7 supported languages (`de`, `en`, `fr`, `it`, `es`, `pt`, `nl`)
- Added a persistent **"Show out-of-stock wines"** toggle in the Settings modal, saved to `localStorage` — preference is remembered between sessions
- The existing quick-toggle button in the filter bar is **unchanged** and still works as a non-persistent shortcut

---

*This contribution was developed with the assistance of [Claude](https://claude.ai) (Anthropic's AI assistant), which helped analyze the codebase, implement the changes, and guide the Git workflow.*