### PR TITLE
Add duplicate wine detection and Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your API key.
+OPENAI_API_KEY=sk-your-openai-api-key
+
+# Optional local overrides.
+OPENAI_MODEL=gpt-5.5
+SECRET_KEY=change-this-to-a-random-string
+CURRENCY=USD

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 RUN_LOCAL_INFO.md
+.env
 wine-tracker/.pytest_cache/
 wine-tracker/app/__pycache__/
 wine-tracker/app/data/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  wine-tracker:
+    image: ha-wine-tracker:local
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "5050:5050"
+    volumes:
+      - wine-data:/data
+    environment:
+      AUTH_ENABLED: "false"
+      SECRET_KEY: "${SECRET_KEY:-local-dev-secret-change-me}"
+      CURRENCY: "${CURRENCY:-USD}"
+      LANGUAGE: "en"
+      AI_PROVIDER: "openai"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      OPENAI_MODEL: "${OPENAI_MODEL:-gpt-5.5}"
+    restart: unless-stopped
+
+volumes:
+  wine-data:

--- a/docs/superpowers/plans/2026-06-21-add-duplicate-detection.md
+++ b/docs/superpowers/plans/2026-06-21-add-duplicate-detection.md
@@ -1,0 +1,560 @@
+# Add-Flow Duplicate Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `POST /add` detect when an incoming wine matches one already in the cellar and let the user merge (bump quantity) or insert separately, instead of always inserting a duplicate.
+
+**Architecture:** Two-phase `/add` driven by a new optional `dup_action` form field. Phase one (no `dup_action`) runs a match query and returns `{ok:false, duplicate:{...}}` without inserting when a match exists. The frontend shows a confirm dialog whose buttons re-POST the same form with `dup_action=merge` (+`dup_target_id`) or `dup_action=separate`. Merge bumps the existing wine's quantity and logs a `restocked` timeline entry. Covers all add paths (AI, Vivino, manual) since they all submit `wineForm` to `/add`.
+
+**Tech Stack:** Python 3.12 / Flask, SQLite, vanilla JS templates (Jinja2), pytest. All Python commands run from `wine-tracker/`.
+
+## Global Constraints
+
+- All Python work runs from the `wine-tracker/` directory.
+- Match rule: `name` (whitespace-trimmed, case-insensitive) **AND** `year` **AND** `bottle_format`. A different vintage or bottle size is NOT a match.
+- Merge changes **quantity only**; all other form fields are ignored on merge.
+- The match query must match regardless of quantity (so empty-bottle placeholders restock).
+- `/edit` and `/duplicate` routes must NOT gain dedup behavior. Only `/add`.
+- Every user-facing string goes through `app/translations.py` for all 7 languages (`de, en, fr, it, es, pt, nl`) — no hardcoded UI text.
+- UI/CSS must reuse existing theme-aware classes (`modal-overlay`, `modal`, `modal-header`, `btn-cancel`, etc.) per `STYLE_GUIDE.md` — no hardcoded theme colors.
+- Restock timeline entry mirrors the existing edit-route pattern (`app/app.py:905-909`): `INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?, "restocked", <added_qty>, datetime.now().isoformat())`.
+
+---
+
+## File Structure
+
+- `wine-tracker/app/app.py` — `/add` route (`app.py:755-811`): add `dup_action` branching, the match query, and the merge branch. Add a small helper `_find_duplicate_wine(db, name, year, bottle_format)`.
+- `wine-tracker/app/translations.py` — new keys in all 7 language dicts.
+- `wine-tracker/app/templates/index.html` — new confirm-dialog modal markup (next to `deleteModal`, ~line 227).
+- `wine-tracker/app/templates/_wine_edit_modal.html` — extend the `wineForm` submit handler (`_wine_edit_modal.html:836-854`) to intercept the duplicate response; add the dialog-button handler functions.
+- `wine-tracker/tests/test_routes.py` — new backend tests.
+
+---
+
+### Task 1: Backend — match helper + two-phase `/add`
+
+**Files:**
+- Modify: `wine-tracker/app/app.py` (route `add()` at `app.py:755-811`; add helper just above it)
+- Test: `wine-tracker/tests/test_routes.py`
+
+**Interfaces:**
+- Consumes: `get_db()`, `wine_json(id)`, `stats_json()`, `is_ajax()`, `datetime`, `date` (all already imported/defined in `app.py`).
+- Produces:
+  - `_find_duplicate_wine(db, name, year, bottle_format) -> sqlite3.Row | None` — returns the most-recent matching wine row or `None`.
+  - `POST /add` now reads form field `dup_action` (`""` | `"separate"` | `"merge"`) and `dup_target_id` (int, required when `dup_action="merge"`).
+  - Phase-one duplicate response shape: `{"ok": false, "duplicate": {"id", "name", "year", "bottle_format", "quantity", "location"}}` (HTTP 200).
+  - Merge success response: `{"ok": true, "wine": <wine_json>, "stats": <stats_json>}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `wine-tracker/tests/test_routes.py`:
+
+```python
+def _add_wine(client, **overrides):
+    data = {
+        "name": "Château Test", "year": "2018", "type": "Rotwein",
+        "region": "Bordeaux, FR", "quantity": "1", "rating": "0",
+        "bottle_format": "0.75",
+    }
+    data.update(overrides)
+    return client.post("/add", data=data,
+                       headers={"X-Requested-With": "XMLHttpRequest"})
+
+
+def test_add_no_existing_inserts_normally(client, db):
+    resp = _add_wine(client, quantity="2")
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    rows = db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()
+    assert rows["c"] == 1
+
+
+def test_add_matching_wine_returns_duplicate_without_inserting(client, db):
+    _add_wine(client, quantity="3")
+    resp = _add_wine(client, quantity="1")
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Château Test"
+    assert body["duplicate"]["year"] == 2018
+    assert body["duplicate"]["quantity"] == 3
+    # Still only ONE row — phase one must not insert
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_bumps_quantity_and_logs_restock(client, db):
+    first = json.loads(_add_wine(client, quantity="3").data)
+    target_id = first["wine"]["id"]
+    resp = _add_wine(client, quantity="2", dup_action="merge",
+                     dup_target_id=str(target_id))
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 5
+    restock = db.execute(
+        "SELECT quantity FROM timeline WHERE wine_id=? AND action='restocked'",
+        (target_id,)).fetchone()
+    assert restock["quantity"] == 2
+
+
+def test_add_separate_inserts_second_row(client, db):
+    _add_wine(client, quantity="1")
+    resp = _add_wine(client, quantity="1", dup_action="separate")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_match_is_case_and_whitespace_insensitive(client, db):
+    _add_wine(client, name="Château Test", quantity="1")
+    resp = _add_wine(client, name="  château test ", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_different_year_is_not_a_match(client, db):
+    _add_wine(client, year="2018", quantity="1")
+    resp = _add_wine(client, year="2019", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_different_bottle_format_is_not_a_match(client, db):
+    _add_wine(client, bottle_format="0.75", quantity="1")
+    resp = _add_wine(client, bottle_format="1.5", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_null_vintage_wines_match(client, db):
+    _add_wine(client, year="", quantity="1")
+    resp = _add_wine(client, year="", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_restocks_empty_bottle(client, db):
+    first = json.loads(_add_wine(client, quantity="1").data)
+    target_id = first["wine"]["id"]
+    db.execute("UPDATE wines SET quantity=0 WHERE id=?", (target_id,))
+    db.commit()
+    _add_wine(client, quantity="2", dup_action="merge", dup_target_id=str(target_id))
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 2
+```
+
+Make sure `import json` is present at the top of `test_routes.py` (it is used elsewhere; add if missing).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py -k "test_add_no_existing or test_add_matching or test_add_merge or test_add_separate or test_add_match_is_case or test_add_different or test_add_null or test_add_merge_restocks" -v`
+Expected: FAIL (new behavior not implemented — e.g. `test_add_matching_wine_returns_duplicate_without_inserting` fails because `ok` is `True`).
+
+- [ ] **Step 3: Add the `_find_duplicate_wine` helper**
+
+Insert directly above `@app.route("/add", methods=["POST"])` (currently `app.py:755`):
+
+```python
+def _find_duplicate_wine(db, name, year, bottle_format):
+    """Return the most-recent wine matching name (trimmed, case-insensitive),
+    year, and bottle_format -- regardless of quantity -- or None."""
+    return db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location
+           FROM wines
+           WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+             AND year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC
+           LIMIT 1""",
+        (name, year, bottle_format),
+    ).fetchone()
+```
+
+- [ ] **Step 4: Rewrite the `add()` route to be two-phase**
+
+Replace the body of `add()` (`app.py:756-811`) with:
+
+```python
+def add():
+    db = get_db()
+    dup_action = request.form.get("dup_action", "").strip()
+
+    # Normalize the same values the matcher and INSERT use.
+    name = request.form["name"].strip()
+    year = request.form.get("year") or None
+    bottle_format_raw = request.form.get("bottle_format", "").strip()
+    bottle_format = float(bottle_format_raw) if bottle_format_raw else 0.75
+    qty = int(request.form.get("quantity", 1))
+
+    # ── Merge: bump an existing wine's quantity, log a restock ──
+    if dup_action == "merge":
+        target_id = request.form.get("dup_target_id", "").strip()
+        target = db.execute(
+            "SELECT id, quantity FROM wines WHERE id=?", (target_id,)
+        ).fetchone() if target_id else None
+        if not target:
+            return jsonify({"ok": False, "error": "merge_target_missing"}), 400
+        db.execute(
+            "UPDATE wines SET quantity = quantity + ? WHERE id=?",
+            (qty, target["id"]),
+        )
+        db.execute(
+            "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+            (target["id"], "restocked", qty, datetime.now().isoformat()),
+        )
+        db.commit()
+        if is_ajax():
+            return jsonify({"ok": True, "wine": wine_json(target["id"]), "stats": stats_json()})
+        return redirect(g.get("ingress", "") + url_for("index"))
+
+    # ── Phase one: unless the user already chose "separate", look for a dup ──
+    if dup_action != "separate":
+        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        if existing:
+            return jsonify({"ok": False, "duplicate": {
+                "id": existing["id"],
+                "name": existing["name"],
+                "year": existing["year"],
+                "bottle_format": existing["bottle_format"],
+                "quantity": existing["quantity"],
+                "location": existing["location"],
+            }})
+
+    # ── Insert (no match, or user chose "separate") ──
+    image = save_image(request.files.get("image"))
+    # If no new image uploaded but AI already saved one, use that
+    if not image:
+        ai_img = request.form.get("ai_image", "").strip()
+        if ai_img and os.path.isfile(os.path.join(UPLOAD_DIR, ai_img)):
+            image = ai_img
+    price_raw = request.form.get("price", "").strip()
+    vivino_raw = request.form.get("vivino_id", "").strip()
+    maturity_data_raw = request.form.get("maturity_data", "").strip() or None
+    taste_profile_raw = request.form.get("taste_profile", "").strip() or None
+    food_pairings_raw = request.form.get("food_pairings", "").strip() or None
+    cur = db.execute(
+        """INSERT INTO wines
+           (name, year, type, region, quantity, rating, notes, image, added,
+            purchased_at, price, drink_from, drink_until, location, grape, vivino_id, bottle_format,
+            maturity_data, taste_profile, food_pairings)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            name,
+            year,
+            request.form.get("type"),
+            request.form.get("region", "").strip(),
+            qty,
+            int(request.form.get("rating", 0)),
+            request.form.get("notes", "").strip(),
+            image,
+            str(date.today()),
+            request.form.get("purchased_at", "").strip() or None,
+            float(price_raw) if price_raw else None,
+            request.form.get("drink_from") or None,
+            request.form.get("drink_until") or None,
+            request.form.get("location", "").strip() or None,
+            request.form.get("grape", "").strip() or None,
+            int(vivino_raw) if vivino_raw else None,
+            bottle_format,
+            maturity_data_raw,
+            taste_profile_raw,
+            food_pairings_raw,
+        ),
+    )
+    db.commit()
+    new_id = cur.lastrowid
+    db.execute(
+        "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+        (new_id, "added", qty, datetime.now().isoformat()),
+    )
+    db.commit()
+    if is_ajax():
+        return jsonify({"ok": True, "wine": wine_json(new_id), "stats": stats_json()})
+    path = g.get("ingress", "") + url_for("index") + f"?new={new_id}"
+    return redirect(path)
+```
+
+Note: this preserves the original insert logic verbatim except that `name`, `year`, `bottle_format`, and `qty` are now computed once at the top and reused.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py -k "test_add_no_existing or test_add_matching or test_add_merge or test_add_separate or test_add_match_is_case or test_add_different or test_add_null or test_add_merge_restocks" -v`
+Expected: PASS (all 9).
+
+- [ ] **Step 6: Run the full suite to check for regressions**
+
+Run: `cd wine-tracker && pytest tests/ -q`
+Expected: PASS (pre-existing add tests still green; the `sample_wine` fixture adds a unique wine so it is unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add wine-tracker/app/app.py wine-tracker/tests/test_routes.py
+git commit -m "Add duplicate detection to /add route (merge/separate/detect)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Translations for the confirm dialog
+
+**Files:**
+- Modify: `wine-tracker/app/translations.py` (all 7 language dicts)
+- Test: `wine-tracker/tests/test_routes.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: 5 new keys in every language dict: `dup_detect_title`, `dup_detect_body`, `dup_detect_merge`, `dup_detect_separate`, `dup_detect_cancel`. `dup_detect_body` contains the placeholder tokens `{qty}`, `{name}`, `{year}`, `{format}`, `{location}` which the frontend substitutes; `dup_detect_merge` contains `{n}` for the resulting quantity.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `wine-tracker/tests/test_routes.py`:
+
+```python
+def test_translations_have_dup_detect_keys():
+    import translations
+    keys = ["dup_detect_title", "dup_detect_body", "dup_detect_merge",
+            "dup_detect_separate", "dup_detect_cancel"]
+    for lang, d in translations.TRANSLATIONS.items():
+        for k in keys:
+            assert k in d, f"{lang} missing {k}"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py::test_translations_have_dup_detect_keys -v`
+Expected: FAIL with AssertionError "de missing dup_detect_title".
+
+- [ ] **Step 3: Add the keys to each language dict**
+
+In `app/translations.py`, add these entries inside each language block (place them near the existing `dup_*` / delete keys for consistency). Use the exact values below.
+
+German (`"de"`):
+```python
+    "dup_detect_title": "Wein bereits vorhanden",
+    "dup_detect_body": "Du hast bereits {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Zum vorhandenen hinzufügen (jetzt {n})",
+    "dup_detect_separate": "Als separaten Eintrag hinzufügen",
+    "dup_detect_cancel": "Abbrechen",
+```
+
+English (`"en"`):
+```python
+    "dup_detect_title": "Wine already in cellar",
+    "dup_detect_body": "You already have {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Add to existing (now {n})",
+    "dup_detect_separate": "Add as separate entry",
+    "dup_detect_cancel": "Cancel",
+```
+
+French (`"fr"`):
+```python
+    "dup_detect_title": "Vin déjà en cave",
+    "dup_detect_body": "Vous avez déjà {qty}x {name} {year} ({format}l) dans {location}.",
+    "dup_detect_merge": "Ajouter à l'existant (désormais {n})",
+    "dup_detect_separate": "Ajouter comme entrée séparée",
+    "dup_detect_cancel": "Annuler",
+```
+
+Italian (`"it"`):
+```python
+    "dup_detect_title": "Vino già in cantina",
+    "dup_detect_body": "Hai già {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aggiungi all'esistente (ora {n})",
+    "dup_detect_separate": "Aggiungi come voce separata",
+    "dup_detect_cancel": "Annulla",
+```
+
+Spanish (`"es"`):
+```python
+    "dup_detect_title": "Vino ya en la bodega",
+    "dup_detect_body": "Ya tienes {qty}x {name} {year} ({format}l) en {location}.",
+    "dup_detect_merge": "Añadir al existente (ahora {n})",
+    "dup_detect_separate": "Añadir como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+```
+
+Portuguese (`"pt"`):
+```python
+    "dup_detect_title": "Vinho já na adega",
+    "dup_detect_body": "Você já tem {qty}x {name} {year} ({format}l) em {location}.",
+    "dup_detect_merge": "Adicionar ao existente (agora {n})",
+    "dup_detect_separate": "Adicionar como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+```
+
+Dutch (`"nl"`):
+```python
+    "dup_detect_title": "Wijn al in kelder",
+    "dup_detect_body": "Je hebt al {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aan bestaande toevoegen (nu {n})",
+    "dup_detect_separate": "Als aparte vermelding toevoegen",
+    "dup_detect_cancel": "Annuleren",
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py::test_translations_have_dup_detect_keys -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wine-tracker/app/translations.py wine-tracker/tests/test_routes.py
+git commit -m "Add dup-detect dialog strings for all 7 languages
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Frontend — confirm dialog markup + submit interception
+
+**Files:**
+- Modify: `wine-tracker/app/templates/index.html` (add modal markup after `deleteModal`, ~line 227)
+- Modify: `wine-tracker/app/templates/_wine_edit_modal.html` (submit handler at lines 836-854; add handler functions)
+
+**Interfaces:**
+- Consumes: backend phase-one response `{ok:false, duplicate:{id,name,year,bottle_format,quantity,location}}`; `window.T` translation dict; existing `openModal(id)` / `closeModal(id)` (`index.html:692,711`); existing `window._onWineSaved(data)` success path.
+- Produces: a `#dupDetectModal` overlay; JS functions `showDupDetectDialog(form, dup)`, `dupMerge()`, `dupSeparate()` on `window`.
+
+- [ ] **Step 1: Add the dialog markup**
+
+In `index.html`, immediately after the `deleteModal` block (after line 227, before the WINE VIEW MODAL comment), add:
+
+```html
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay" id="dupDetectModal">
+  <div class="modal" style="max-width:380px">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
+      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
+```
+
+(Reuses existing theme-aware classes `modal-overlay`, `modal`, `modal-header`, `delete-confirm-body`, `delete-confirm-actions`, `btn-submit` (the primary Save-button class, `_wine_edit_modal.html:145` / `style.css:870`), `btn-cancel`.)
+
+- [ ] **Step 2: Intercept the duplicate response in the submit handler**
+
+In `_wine_edit_modal.html`, replace the submit handler body (lines 836-854) with:
+
+```javascript
+var _dupPendingForm = null;
+var _dupPending = null;
+
+document.getElementById('wineForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  var form = this;
+  submitWineForm(form, null);
+});
+
+function submitWineForm(form, dupAction, targetId) {
+  var fd = new FormData(form);
+  if (dupAction) {
+    fd.set('dup_action', dupAction);
+    if (targetId != null) fd.set('dup_target_id', targetId);
+  }
+  fetch(form.action, {
+    method: 'POST', body: fd,
+    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    // Duplicate detected on an /add submit -> ask the user.
+    if (!data.ok && data.duplicate) {
+      showDupDetectDialog(form, data.duplicate);
+      return;
+    }
+    if (!data.ok) return;
+    closeModal('dupDetectModal');
+    closeModal('wineModal');
+    if (typeof window._onWineSaved === 'function') {
+      window._onWineSaved(data);
+    } else {
+      window.location.reload();
+    }
+  });
+}
+
+function showDupDetectDialog(form, dup) {
+  _dupPendingForm = form;
+  _dupPending = dup;
+  var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
+  var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
+  var body = (window.T.dup_detect_body || '')
+    .replace('{qty}', dup.quantity)
+    .replace('{name}', dup.name || '')
+    .replace('{year}', dup.year || '')
+    .replace('{format}', fmt)
+    .replace('{location}', dup.location || '-');
+  document.getElementById('dupDetectBody').textContent = body;
+  document.getElementById('dupMergeBtn').textContent =
+    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  openModal('dupDetectModal');
+}
+
+function dupMerge() {
+  if (_dupPendingForm && _dupPending) {
+    submitWineForm(_dupPendingForm, 'merge', _dupPending.id);
+  }
+}
+
+function dupSeparate() {
+  if (_dupPendingForm) {
+    submitWineForm(_dupPendingForm, 'separate');
+  }
+}
+```
+
+Note: `closeModal('dupDetectModal')` is called on success so the dialog closes after a merge/separate completes. The `dupDetectModal` lives in `index.html` and `openModal`/`closeModal` are global, so they are reachable from this included template.
+
+- [ ] **Step 3: Manual verification (no automated frontend test in this repo)**
+
+Run the dev server and exercise the flow:
+
+```bash
+cd /Users/ofer/conductor/workspaces/ha-wine-tracker/riyadh && ./scripts/run-dev.sh
+```
+
+Then in the browser at http://localhost:5050:
+1. Add a wine "Verify Wine" 2018, 0.75l, qty 2 → it appears.
+2. Add "Verify Wine" 2018, 0.75l, qty 1 again → the duplicate dialog appears showing "You already have 2x Verify Wine 2018 (0.75l) in ...", merge button reads "Add to existing (now 3)".
+3. Click merge → card quantity becomes 3, no second card.
+4. Repeat add, click "Add as separate entry" → a second card appears.
+5. Add a different vintage 2019 → inserts directly, no dialog.
+
+Expected: all five behave as described. Stop the server with Ctrl-C.
+
+- [ ] **Step 4: Run the full test suite (ensure backend still green)**
+
+Run: `cd wine-tracker && pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wine-tracker/app/templates/index.html wine-tracker/app/templates/_wine_edit_modal.html
+git commit -m "Add duplicate-detect confirm dialog to the add flow
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** match rule (Task 1 helper + tests), two-phase `/add` (Task 1), merge = quantity only + restock timeline (Task 1), empty-bottle restock (Task 1 test), all 7 languages (Task 2), three-button dialog reusing theme classes (Task 3), `/edit` & `/duplicate` untouched (only `add()` changed). All covered.
+- **Edit route unaffected:** the new `submitWineForm` is shared by add and edit, but `dup_action` is only ever sent by the dialog buttons, and the backend only inspects `dup_action` in `/add`. `/edit` ignores unknown form fields. Edit submits therefore behave exactly as before.
+- **Placeholder scan:** none.
+- **Type consistency:** `_find_duplicate_wine` returns a Row consumed only inside `add()`; frontend `dup.id`/`dup.quantity` match the JSON keys produced in Task 1; `{n}`/`{qty}`/`{format}` tokens in Task 2 match the `.replace(...)` calls in Task 3.
+- **Button class verified:** the primary Save button uses `btn-submit` (`_wine_edit_modal.html:145`, `style.css:870`); the dialog's merge button reuses it.

--- a/docs/superpowers/specs/2026-06-21-add-duplicate-detection-design.md
+++ b/docs/superpowers/specs/2026-06-21-add-duplicate-detection-design.md
@@ -1,0 +1,142 @@
+# Duplicate detection on the add flow — design
+
+**Date:** 2026-06-21
+**Status:** Approved (pending implementation)
+
+## Problem
+
+Adding a wine via the AI label feature (or Vivino search, or manually) always inserts
+a new row through `POST /add`. There is no check against the existing cellar, so re-adding
+a wine you already own produces a second card instead of bumping its quantity. Deduplication
+currently exists **only** in the ZIP/CSV restore path (`match_wines()` in `export_import.py`),
+never in the normal add flow.
+
+This adds opt-in duplicate detection to `POST /add` so the user is asked what to do when an
+incoming wine matches one already in the cellar.
+
+## Scope
+
+- Lives entirely in `POST /add`, so it covers **all** add paths (AI, Vivino, manual) at once.
+- `/edit` and `/duplicate` are untouched. (`/duplicate` is intentional cloning.)
+- No schema change. No new columns.
+
+## Matching rule
+
+A wine is "the same" when **all three** match:
+
+- `name` — case-insensitive, whitespace-trimmed on both sides
+- `year` (vintage)
+- `bottle_format`
+
+A different vintage **or** a different bottle size is a distinct cellar entry and does **not** match.
+
+Match query (most-recent first, first row wins):
+
+```sql
+SELECT id, name, year, bottle_format, quantity, location
+FROM wines
+WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+  AND year IS ?
+  AND bottle_format = ?
+ORDER BY id DESC
+LIMIT 1
+```
+
+Notes:
+- Matches **regardless of quantity**, so an empty-bottle placeholder (quantity 0) of the same
+  wine gets restocked rather than duplicated.
+- `year IS ?` handles the NULL-vintage case correctly (`NULL IS NULL` is true in SQLite).
+- `bottle_format` defaults to `0.75` on insert when the form value is empty; the form always
+  submits a value, so the comparison is stable.
+- If multiple separate entries share the same name/year/format (e.g. different storage
+  locations), the most recent one is offered. The dialog shows its `location` so the user can
+  choose "Add as separate entry" if it is the wrong one. Resolving multi-match precisely is out
+  of scope for v1.
+
+## Mechanism — two-phase `/add`
+
+`/add` gains one optional form field, `dup_action`:
+
+| `dup_action` | Behavior |
+|---|---|
+| _(empty, default)_ | Run the match query. **If a match exists, do not insert** — return `{"ok": false, "duplicate": {...}}`. If no match, insert as today. |
+| `"separate"` | Skip the check entirely; insert a new row as today. |
+| `"merge"` (with `dup_target_id`) | Increment the target wine's `quantity` by the form quantity, log a `restocked` timeline entry, return `{"ok": true, "wine": ..., "stats": ...}`. |
+
+The `duplicate` payload returned in phase one:
+
+```json
+{
+  "ok": false,
+  "duplicate": {
+    "id": 12,
+    "name": "Château Test",
+    "year": 2018,
+    "bottle_format": 0.75,
+    "quantity": 3,
+    "location": "Keller A"
+  }
+}
+```
+
+### Merge semantics (decision: quantity only)
+
+On `merge`, only the quantity changes. All other form fields (notes, rating, maturity data,
+price, location, image, etc.) are **ignored** — the existing card stays the source of truth.
+Enriching an existing wine is already covered by the separate "Reload missing data" feature.
+
+Increment amount = the `quantity` field from the form (so adding 2 bottles bumps 3 → 5).
+The timeline entry mirrors the existing edit-route pattern (`app.py:905-909`):
+
+```python
+db.execute(
+    "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+    (target_id, "restocked", added_qty, datetime.now().isoformat()),
+)
+```
+
+### Readonly / auth
+
+`merge` and `separate` are write operations and must pass the same `check_readonly()` /
+`check_auth()` gates the rest of `/add` already enforces. No special-casing needed since they
+flow through the same route.
+
+## Frontend — add-form submit (`index.html`)
+
+The existing add-form submit posts a `FormData` to `/add` via fetch and updates the UI on
+`ok:true`. Change the response handling:
+
+1. On `{ok:false, duplicate}` → show a confirm dialog (reusing the app's existing modal/dialog
+   styling, theme-aware per `STYLE_GUIDE.md`) showing:
+   `You already have {quantity}× {name} {year} ({bottle_format}l) in {location}.`
+   with three buttons:
+   - **Add to existing (now N)** → re-POST the same FormData with `dup_action=merge` and
+     `dup_target_id=<id>`.
+   - **Add as separate entry** → re-POST the same FormData with `dup_action=separate`.
+   - **Cancel** → close dialog, leave the add form open and untouched.
+2. On `{ok:false}` with any other error → existing error handling, unchanged.
+3. On `{ok:true}` → existing success handling, unchanged.
+
+All three button labels and the dialog body text go through `translations.py` for all 7
+languages (new keys, e.g. `dup_detect_title`, `dup_detect_body`, `dup_detect_merge`,
+`dup_detect_separate`, `dup_detect_cancel`).
+
+## Tests (`tests/test_routes.py`)
+
+- No existing wine → `/add` inserts normally, `ok:true` (regression).
+- Matching wine, no `dup_action` → `ok:false` with correct `duplicate` payload; **no new row** inserted.
+- `dup_action=merge` + `dup_target_id` → target quantity increased by form quantity; a
+  `restocked` timeline row is written; no new wine row.
+- `dup_action=separate` → a second row is inserted despite the match.
+- Case-insensitive + whitespace match: `"  château test "` matches `"Château Test"`.
+- Different `year` → no match (inserts).
+- Different `bottle_format` → no match (inserts).
+- NULL-vintage match: two wines with `year=NULL`, same name/format → match.
+- Empty-bottle restock: existing match with `quantity=0`, merge → quantity becomes the form qty.
+
+## Out of scope
+
+- Field backfill on merge (option B from brainstorming) — explicitly rejected for v1.
+- Multi-match disambiguation UI.
+- Dedup on `/edit`.
+- Changing the import (`match_wines`) behavior.

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -1,11 +1,14 @@
 import json
 import os
+import re
 import secrets
 import shutil
 import sqlite3
+import unicodedata
 import uuid
 from collections import defaultdict
 from datetime import date, datetime
+from difflib import SequenceMatcher
 from flask import Flask, render_template, request, redirect, url_for, send_from_directory, jsonify, g, session, Response
 from werkzeug.security import generate_password_hash, check_password_hash
 from translations import TRANSLATIONS
@@ -752,10 +755,63 @@ def index():
     )
 
 
-def _find_duplicate_wine(db, name, year, bottle_format):
-    """Return the most-recent wine matching name (trimmed, case-insensitive),
-    year, and bottle_format -- regardless of quantity -- or None."""
-    return db.execute(
+def _normalize_duplicate_name(value):
+    """Normalize AI/user label text enough for duplicate-name comparison."""
+    folded = unicodedata.normalize("NFKD", value or "")
+    ascii_text = folded.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", ascii_text.lower())).strip()
+
+
+def _duplicate_name_tokens(value):
+    return tuple(_normalize_duplicate_name(value).split())
+
+
+def _is_contextual_name_variant(left_name, right_name, context_values):
+    """Return True when one wine name is the other plus region/grape/type text."""
+    left = _duplicate_name_tokens(left_name)
+    right = _duplicate_name_tokens(right_name)
+    if not left or not right:
+        return False
+
+    shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+    if len(shorter) < 2 or tuple(longer[:len(shorter)]) != shorter:
+        return False
+
+    suffix = longer[len(shorter):]
+    if not suffix:
+        return True
+
+    context_tokens = set()
+    for value in context_values:
+        context_tokens.update(_duplicate_name_tokens(value))
+    return bool(context_tokens) and set(suffix).issubset(context_tokens)
+
+
+def _is_fuzzy_duplicate_name(left_name, right_name, context_values=()):
+    left_norm = _normalize_duplicate_name(left_name)
+    right_norm = _normalize_duplicate_name(right_name)
+    if not left_norm or not right_norm:
+        return False
+    if left_norm == right_norm:
+        return True
+    if _is_contextual_name_variant(left_name, right_name, context_values):
+        return True
+
+    left_tokens = _duplicate_name_tokens(left_name)
+    right_tokens = _duplicate_name_tokens(right_name)
+    if not left_tokens or not right_tokens or left_tokens[0] != right_tokens[0]:
+        return False
+
+    return SequenceMatcher(None, left_norm, right_norm).ratio() >= 0.92
+
+
+def _find_duplicate_wine(db, name, year, bottle_format, region=None, grape=None, wine_type=None):
+    """Return the most-recent wine matching name, year, and bottle_format.
+
+    Exact name matches are case-insensitive. A conservative fuzzy fallback catches
+    AI label variants such as appending the same region to the wine name.
+    """
+    exact = db.execute(
         """SELECT id, name, year, bottle_format, quantity, location
            FROM wines
            WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
@@ -765,6 +821,25 @@ def _find_duplicate_wine(db, name, year, bottle_format):
            LIMIT 1""",
         (name, year, bottle_format),
     ).fetchone()
+    if exact:
+        return exact
+
+    submitted_context = (region, grape, wine_type)
+    candidates = db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location, region, grape, type
+           FROM wines
+           WHERE year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC""",
+        (year, bottle_format),
+    ).fetchall()
+    for candidate in candidates:
+        context_values = submitted_context + (
+            candidate["region"], candidate["grape"], candidate["type"],
+        )
+        if _is_fuzzy_duplicate_name(name, candidate["name"], context_values):
+            return candidate
+    return None
 
 
 @app.route("/add", methods=["POST"])
@@ -802,7 +877,15 @@ def add():
 
     # -- Phase one: unless the user already chose "separate", look for a dup --
     if dup_action != "separate":
-        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        existing = _find_duplicate_wine(
+            db,
+            name,
+            year,
+            bottle_format,
+            request.form.get("region"),
+            request.form.get("grape"),
+            request.form.get("type"),
+        )
         if existing:
             return jsonify({"ok": False, "duplicate": {
                 "id": existing["id"],

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -752,9 +752,68 @@ def index():
     )
 
 
+def _find_duplicate_wine(db, name, year, bottle_format):
+    """Return the most-recent wine matching name (trimmed, case-insensitive),
+    year, and bottle_format -- regardless of quantity -- or None."""
+    return db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location
+           FROM wines
+           WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+             AND year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC
+           LIMIT 1""",
+        (name, year, bottle_format),
+    ).fetchone()
+
+
 @app.route("/add", methods=["POST"])
 def add():
     db = get_db()
+    dup_action = request.form.get("dup_action", "").strip()
+
+    # Normalize the same values the matcher and INSERT use.
+    name = request.form["name"].strip()
+    year = request.form.get("year") or None
+    bottle_format_raw = request.form.get("bottle_format", "").strip()
+    bottle_format = float(bottle_format_raw) if bottle_format_raw else 0.75
+    qty = int(request.form.get("quantity", 1))
+
+    # -- Merge: bump an existing wine's quantity, log a restock --
+    if dup_action == "merge":
+        target_id = request.form.get("dup_target_id", "").strip()
+        target = db.execute(
+            "SELECT id, quantity FROM wines WHERE id=?", (target_id,)
+        ).fetchone() if target_id else None
+        if not target:
+            return jsonify({"ok": False, "error": "merge_target_missing"}), 400
+        db.execute(
+            "UPDATE wines SET quantity = quantity + ? WHERE id=?",
+            (qty, target["id"]),
+        )
+        db.execute(
+            "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+            (target["id"], "restocked", qty, datetime.now().isoformat()),
+        )
+        db.commit()
+        if is_ajax():
+            return jsonify({"ok": True, "wine": wine_json(target["id"]), "stats": stats_json()})
+        return redirect(g.get("ingress", "") + url_for("index"))
+
+    # -- Phase one: unless the user already chose "separate", look for a dup --
+    if dup_action != "separate":
+        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        if existing:
+            return jsonify({"ok": False, "duplicate": {
+                "id": existing["id"],
+                "name": existing["name"],
+                "year": existing["year"],
+                "bottle_format": existing["bottle_format"],
+                "quantity": existing["quantity"],
+                "location": existing["location"],
+            }})
+
+    # -- Insert (no match, or user chose "separate") --
     image = save_image(request.files.get("image"))
     # If no new image uploaded but AI already saved one, use that
     if not image:
@@ -763,7 +822,6 @@ def add():
             image = ai_img
     price_raw = request.form.get("price", "").strip()
     vivino_raw = request.form.get("vivino_id", "").strip()
-    bottle_format_raw = request.form.get("bottle_format", "").strip()
     maturity_data_raw = request.form.get("maturity_data", "").strip() or None
     taste_profile_raw = request.form.get("taste_profile", "").strip() or None
     food_pairings_raw = request.form.get("food_pairings", "").strip() or None
@@ -774,11 +832,11 @@ def add():
             maturity_data, taste_profile, food_pairings)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
-            request.form["name"].strip(),
-            request.form.get("year") or None,
+            name,
+            year,
             request.form.get("type"),
             request.form.get("region", "").strip(),
-            int(request.form.get("quantity", 1)),
+            qty,
             int(request.form.get("rating", 0)),
             request.form.get("notes", "").strip(),
             image,
@@ -790,7 +848,7 @@ def add():
             request.form.get("location", "").strip() or None,
             request.form.get("grape", "").strip() or None,
             int(vivino_raw) if vivino_raw else None,
-            float(bottle_format_raw) if bottle_format_raw else 0.75,
+            bottle_format,
             maturity_data_raw,
             taste_profile_raw,
             food_pairings_raw,
@@ -798,8 +856,6 @@ def add():
     )
     db.commit()
     new_id = cur.lastrowid
-    # Log the addition
-    qty = int(request.form.get("quantity", 1))
     db.execute(
         "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
         (new_id, "added", qty, datetime.now().isoformat()),

--- a/wine-tracker/app/static/style.css
+++ b/wine-tracker/app/static/style.css
@@ -802,6 +802,16 @@ html.light .filter-option:hover { background: rgba(0,0,0,.05); }
 /* Duplicate modal */
 .dup-hint { font-size: .82rem; color: var(--muted); background: var(--bg);
             border-radius: 8px; padding: .75rem; line-height: 1.5; }
+.duplicate-detect-overlay { z-index: 260; }
+.duplicate-detect-modal { max-width: 380px; }
+.duplicate-detect-actions {
+  flex-direction: column;
+  gap: 8px;
+}
+.duplicate-detect-actions .btn-submit,
+.duplicate-detect-actions .btn-cancel {
+  width: 100%;
+}
 
 /* ── Form Elements ─────────────────────────────────────────────────────────── */
 label { font-size: .8rem; color: var(--muted); display: block; margin-bottom: .25rem; }

--- a/wine-tracker/app/templates/_wine_edit_modal.html
+++ b/wine-tracker/app/templates/_wine_edit_modal.html
@@ -833,17 +833,34 @@ function reloadViaVivino() {
 // Uses a callback pattern: if window._onWineSaved is defined, call it;
 // otherwise reload the page.
 
+var _dupPendingForm = null;
+var _dupPending = null;
+
 document.getElementById('wineForm').addEventListener('submit', function(e) {
   e.preventDefault();
   var form = this;
+  submitWineForm(form, null);
+});
+
+function submitWineForm(form, dupAction, targetId) {
   var fd = new FormData(form);
+  if (dupAction) {
+    fd.set('dup_action', dupAction);
+    if (targetId != null) fd.set('dup_target_id', targetId);
+  }
   fetch(form.action, {
     method: 'POST', body: fd,
     headers: { 'X-Requested-With': 'XMLHttpRequest' }
   })
   .then(function(r) { return r.json(); })
   .then(function(data) {
+    // Duplicate detected on an /add submit -> ask the user.
+    if (!data.ok && data.duplicate) {
+      showDupDetectDialog(form, data.duplicate);
+      return;
+    }
     if (!data.ok) return;
+    closeModal('dupDetectModal');
     closeModal('wineModal');
     if (typeof window._onWineSaved === 'function') {
       window._onWineSaved(data);
@@ -851,7 +868,36 @@ document.getElementById('wineForm').addEventListener('submit', function(e) {
       window.location.reload();
     }
   });
-});
+}
+
+function showDupDetectDialog(form, dup) {
+  _dupPendingForm = form;
+  _dupPending = dup;
+  var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
+  var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
+  var body = (window.T.dup_detect_body || '')
+    .replace('{qty}', dup.quantity)
+    .replace('{name}', dup.name || '')
+    .replace('{year}', dup.year || '')
+    .replace('{format}', fmt)
+    .replace('{location}', dup.location || '-');
+  document.getElementById('dupDetectBody').textContent = body;
+  document.getElementById('dupMergeBtn').textContent =
+    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  openModal('dupDetectModal');
+}
+
+function dupMerge() {
+  if (_dupPendingForm && _dupPending) {
+    submitWineForm(_dupPendingForm, 'merge', _dupPending.id);
+  }
+}
+
+function dupSeparate() {
+  if (_dupPendingForm) {
+    submitWineForm(_dupPendingForm, 'separate');
+  }
+}
 
 // ── Modal overlay / ESC handling for wineModal ──────────────────────────────
 // Other pages set up generic overlay click handlers; we need the wineModal-specific

--- a/wine-tracker/app/templates/_wine_edit_modal.html
+++ b/wine-tracker/app/templates/_wine_edit_modal.html
@@ -150,6 +150,25 @@
   </div>
 </div>
 
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay duplicate-detect-overlay" id="dupDetectModal">
+  <div class="modal duplicate-detect-modal">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="cancelDupDetectDialog()">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions duplicate-detect-actions">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()"></button>
+      <button class="btn-cancel" onclick="dupSeparate()">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="cancelDupDetectDialog()">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
+
 <script src="{{ ingress }}/static/wine-modal.js"></script>
 <script>
 // ── Wine Edit Modal JS ──────────────────────────────────────────────────────
@@ -860,6 +879,7 @@ function submitWineForm(form, dupAction, targetId) {
       return;
     }
     if (!data.ok) return;
+    resetDupDetectDialog();
     closeModal('dupDetectModal');
     closeModal('wineModal');
     if (typeof window._onWineSaved === 'function') {
@@ -873,6 +893,9 @@ function submitWineForm(form, dupAction, targetId) {
 function showDupDetectDialog(form, dup) {
   _dupPendingForm = form;
   _dupPending = dup;
+  var bodyEl = document.getElementById('dupDetectBody');
+  var mergeBtn = document.getElementById('dupMergeBtn');
+  if (!bodyEl || !mergeBtn) return;
   var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
   var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
   var body = (window.T.dup_detect_body || '')
@@ -881,10 +904,19 @@ function showDupDetectDialog(form, dup) {
     .replace('{year}', dup.year || '')
     .replace('{format}', fmt)
     .replace('{location}', dup.location || '-');
-  document.getElementById('dupDetectBody').textContent = body;
-  document.getElementById('dupMergeBtn').textContent =
-    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  bodyEl.textContent = body;
+  mergeBtn.textContent = (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
   openModal('dupDetectModal');
+}
+
+function resetDupDetectDialog() {
+  _dupPendingForm = null;
+  _dupPending = null;
+}
+
+function cancelDupDetectDialog() {
+  resetDupDetectDialog();
+  closeModal('dupDetectModal');
 }
 
 function dupMerge() {

--- a/wine-tracker/app/templates/index.html
+++ b/wine-tracker/app/templates/index.html
@@ -226,6 +226,24 @@
   </div>
 </div>
 
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay" id="dupDetectModal">
+  <div class="modal" style="max-width:380px">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
+      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
 
 <!-- ═══════════════ WINE VIEW MODAL ═══════════════ -->
 {% include '_wine_view_modal.html' %}

--- a/wine-tracker/app/templates/index.html
+++ b/wine-tracker/app/templates/index.html
@@ -226,25 +226,6 @@
   </div>
 </div>
 
-<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
-<div class="modal-overlay" id="dupDetectModal">
-  <div class="modal" style="max-width:380px">
-    <div class="modal-header">
-      {{ t.dup_detect_title }}
-      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
-    </div>
-    <div class="delete-confirm-body">
-      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
-      <div class="delete-confirm-msg" id="dupDetectBody"></div>
-    </div>
-    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
-      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
-      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
-      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
-    </div>
-  </div>
-</div>
-
 <!-- ═══════════════ WINE VIEW MODAL ═══════════════ -->
 {% include '_wine_view_modal.html' %}
 {% include '_wine_view_extras.html' %}

--- a/wine-tracker/app/translations.py
+++ b/wine-tracker/app/translations.py
@@ -207,6 +207,13 @@ TRANSLATIONS = {
     "dup_hint": "Alle anderen Felder (Typ, Region, Bewertung, Notizen, Foto) werden übernommen.",
     "btn_create_dup": "Duplikat anlegen",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Wein bereits vorhanden",
+    "dup_detect_body": "Du hast bereits {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Zum vorhandenen hinzufügen (jetzt {n})",
+    "dup_detect_separate": "Als separaten Eintrag hinzufügen",
+    "dup_detect_cancel": "Abbrechen",
+
     # Empty states
     "empty_no_wines": "Noch keine Weine erfasst.",
     "empty_add_first": "Füge deinen ersten Wein hinzu!",
@@ -554,6 +561,13 @@ TRANSLATIONS = {
     "dup_hint": "All other fields (type, region, rating, notes, photo) will be copied.",
     "btn_create_dup": "Create duplicate",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Wine already in cellar",
+    "dup_detect_body": "You already have {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Add to existing (now {n})",
+    "dup_detect_separate": "Add as separate entry",
+    "dup_detect_cancel": "Cancel",
+
     "empty_no_wines": "No wines recorded yet.",
     "empty_add_first": "Add your first wine!",
     "empty_no_results": "No wines found.",
@@ -896,6 +910,13 @@ TRANSLATIONS = {
     "dup_qty": "Quantité",
     "dup_hint": "Tous les autres champs (type, région, note, notes, photo) seront copiés.",
     "btn_create_dup": "Créer le duplicata",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Vin déjà en cave",
+    "dup_detect_body": "Vous avez déjà {qty}x {name} {year} ({format}l) dans {location}.",
+    "dup_detect_merge": "Ajouter à l'existant (désormais {n})",
+    "dup_detect_separate": "Ajouter comme entrée séparée",
+    "dup_detect_cancel": "Annuler",
 
     "empty_no_wines": "Aucun vin enregistré.",
     "empty_add_first": "Ajoutez votre premier vin !",
@@ -1240,6 +1261,13 @@ TRANSLATIONS = {
     "dup_hint": "Tutti gli altri campi (tipo, regione, valutazione, note, foto) verranno copiati.",
     "btn_create_dup": "Crea duplicato",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Vino già in cantina",
+    "dup_detect_body": "Hai già {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aggiungi all'esistente (ora {n})",
+    "dup_detect_separate": "Aggiungi come voce separata",
+    "dup_detect_cancel": "Annulla",
+
     "empty_no_wines": "Nessun vino registrato.",
     "empty_add_first": "Aggiungi il tuo primo vino!",
     "empty_no_results": "Nessun vino trovato.",
@@ -1582,6 +1610,13 @@ TRANSLATIONS = {
     "dup_qty": "Cantidad",
     "dup_hint": "Todos los demás campos (tipo, región, valoración, notas, foto) se copiarán.",
     "btn_create_dup": "Crear duplicado",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Vino ya en la bodega",
+    "dup_detect_body": "Ya tienes {qty}x {name} {year} ({format}l) en {location}.",
+    "dup_detect_merge": "Añadir al existente (ahora {n})",
+    "dup_detect_separate": "Añadir como entrada separada",
+    "dup_detect_cancel": "Cancelar",
 
     "empty_no_wines": "No hay vinos registrados.",
     "empty_add_first": "¡Añade tu primer vino!",
@@ -1926,6 +1961,13 @@ TRANSLATIONS = {
     "dup_hint": "Todos os outros campos (tipo, região, avaliação, notas, foto) serão copiados.",
     "btn_create_dup": "Criar duplicata",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Vinho já na adega",
+    "dup_detect_body": "Você já tem {qty}x {name} {year} ({format}l) em {location}.",
+    "dup_detect_merge": "Adicionar ao existente (agora {n})",
+    "dup_detect_separate": "Adicionar como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+
     "empty_no_wines": "Nenhum vinho registrado.",
     "empty_add_first": "Adicione seu primeiro vinho!",
     "empty_no_results": "Nenhum vinho encontrado.",
@@ -2268,6 +2310,13 @@ TRANSLATIONS = {
     "dup_qty": "Aantal",
     "dup_hint": "Alle andere velden (type, regio, beoordeling, notities, foto) worden gekopieerd.",
     "btn_create_dup": "Duplicaat maken",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Wijn al in kelder",
+    "dup_detect_body": "Je hebt al {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aan bestaande toevoegen (nu {n})",
+    "dup_detect_separate": "Als aparte vermelding toevoegen",
+    "dup_detect_cancel": "Annuleren",
 
     "empty_no_wines": "Nog geen wijnen geregistreerd.",
     "empty_add_first": "Voeg je eerste wijn toe!",

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -111,6 +111,13 @@ class TestIndex:
         resp = client.get("/")
         assert b'id="viewModal"' in resp.data
 
+    def test_duplicate_detect_modal_present_once(self, client):
+        """Duplicate-detect dialog belongs to the shared add/edit modal stack."""
+        resp = client.get("/")
+        html = resp.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
+        assert 'duplicate-detect-overlay' in html
+
     def test_card_body_calls_view(self, client, sample_wine):
         """Card body onclick should call viewFromCard."""
         resp = client.get("/")
@@ -561,6 +568,7 @@ class TestStatsPage:
         html = resp.data.decode()
         assert 'id="wineModal"' in html
         assert 'id="wineForm"' in html
+        assert html.count('id="dupDetectModal"') == 1
 
     def test_stats_stock_chart_with_timeline(self, client, sample_wine, db):
         """Stats page should include stock chart data when timeline entries exist."""
@@ -681,6 +689,11 @@ class TestTimelinePage:
         resp = client.get("/timeline")
         assert resp.status_code == 200
         assert b"timeline" in resp.data.lower() or b"Zeitverlauf" in resp.data
+
+    def test_timeline_has_duplicate_detect_modal(self, client):
+        resp = client.get("/timeline")
+        html = resp.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
 
 
 # ── Wine log integration ─────────────────────────────────────────────────────
@@ -821,6 +834,19 @@ class TestChatPage:
         assert "openViewModal" in html
         assert "/api/wine/" in html
         assert 'id="viewModal"' in html
+
+    @patch("app.load_options")
+    def test_chat_has_duplicate_detect_modal(self, mock_opts, client):
+        mock_opts.return_value = {
+            "currency": "CHF", "language": "en",
+            "ai_provider": "anthropic", "anthropic_api_key": "sk-test",
+            "anthropic_model": "claude-sonnet-4-20250514",
+            "openai_api_key": "", "openrouter_api_key": "",
+            "ollama_host": "", "ollama_model": "",
+        }
+        response = client.get("/chat")
+        html = response.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
 
     @patch("app.load_options")
     def test_chat_new_button_closes_history_sidebar_on_mobile(self, mock_opts, client):
@@ -1245,6 +1271,49 @@ def test_add_match_is_case_and_whitespace_insensitive(client, db):
     _add_wine(client, name="Château Test", quantity="1")
     resp = _add_wine(client, name="  château test ", quantity="1")
     assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_contextual_ai_name_variant_returns_duplicate(client, db):
+    _add_wine(
+        client,
+        name="Raeburn Pinot Noir",
+        year="2023",
+        region="Sonoma County, California",
+        grape="Pinot Noir",
+        quantity="1",
+    )
+    resp = _add_wine(
+        client,
+        name="Raeburn Pinot Noir Sonoma County",
+        year="2023",
+        region="Sonoma County, California",
+        grape="Pinot Noir",
+        quantity="6",
+    )
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Raeburn Pinot Noir"
+    assert body["duplicate"]["quantity"] == 1
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_prefix_with_non_context_suffix_is_not_a_match(client, db):
+    _add_wine(
+        client,
+        name="Château Test",
+        year="2018",
+        region="Bordeaux, FR",
+        quantity="1",
+    )
+    resp = _add_wine(
+        client,
+        name="Château Test Reserve",
+        year="2018",
+        region="Bordeaux, FR",
+        quantity="1",
+    )
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
 
 
 def test_add_different_year_is_not_a_match(client, db):

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -1183,3 +1183,105 @@ class TestDevAuth:
         resp = client.get("/", follow_redirects=False)
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
+
+
+# ── Duplicate detection on /add ───────────────────────────────────────────────
+
+def _add_wine(client, **overrides):
+    data = {
+        "name": "Château Test", "year": "2018", "type": "Rotwein",
+        "region": "Bordeaux, FR", "quantity": "1", "rating": "0",
+        "bottle_format": "0.75",
+    }
+    data.update(overrides)
+    return client.post("/add", data=data,
+                       headers={"X-Requested-With": "XMLHttpRequest"})
+
+
+def test_add_no_existing_inserts_normally(client, db):
+    resp = _add_wine(client, quantity="2")
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    rows = db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()
+    assert rows["c"] == 1
+
+
+def test_add_matching_wine_returns_duplicate_without_inserting(client, db):
+    _add_wine(client, quantity="3")
+    resp = _add_wine(client, quantity="1")
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Château Test"
+    assert body["duplicate"]["year"] == 2018
+    assert body["duplicate"]["quantity"] == 3
+    # Still only ONE row — phase one must not insert
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_bumps_quantity_and_logs_restock(client, db):
+    first = json.loads(_add_wine(client, quantity="3").data)
+    target_id = first["wine"]["id"]
+    resp = _add_wine(client, quantity="2", dup_action="merge",
+                     dup_target_id=str(target_id))
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 5
+    restock = db.execute(
+        "SELECT quantity FROM timeline WHERE wine_id=? AND action='restocked'",
+        (target_id,)).fetchone()
+    assert restock["quantity"] == 2
+
+
+def test_add_separate_inserts_second_row(client, db):
+    _add_wine(client, quantity="1")
+    resp = _add_wine(client, quantity="1", dup_action="separate")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_match_is_case_and_whitespace_insensitive(client, db):
+    _add_wine(client, name="Château Test", quantity="1")
+    resp = _add_wine(client, name="  château test ", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_different_year_is_not_a_match(client, db):
+    _add_wine(client, year="2018", quantity="1")
+    resp = _add_wine(client, year="2019", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_different_bottle_format_is_not_a_match(client, db):
+    _add_wine(client, bottle_format="0.75", quantity="1")
+    resp = _add_wine(client, bottle_format="1.5", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_null_vintage_wines_match(client, db):
+    _add_wine(client, year="", quantity="1")
+    resp = _add_wine(client, year="", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_restocks_empty_bottle(client, db):
+    first = json.loads(_add_wine(client, quantity="1").data)
+    target_id = first["wine"]["id"]
+    db.execute("UPDATE wines SET quantity=0 WHERE id=?", (target_id,))
+    db.commit()
+    _add_wine(client, quantity="2", dup_action="merge", dup_target_id=str(target_id))
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 2
+
+
+def test_translations_have_dup_detect_keys():
+    import translations
+    keys = ["dup_detect_title", "dup_detect_body", "dup_detect_merge",
+            "dup_detect_separate", "dup_detect_cancel"]
+    for lang, d in translations.TRANSLATIONS.items():
+        for k in keys:
+            assert k in d, f"{lang} missing {k}"


### PR DESCRIPTION
## Summary
- add duplicate detection to the add-wine flow
- add duplicate restock handling in the edit modal flow
- add local Docker Compose setup and supporting docs

## Commits included
- 735b2c4 Add duplicate detection to the add-wine flow (#1)
- 050bd89 Add local Docker Compose setup (#2)
- 15b2a48 Fix duplicate wine restock flow (#3)

## Tests
- Not run in this PR creation step