### PR TITLE
Add duplicate wine detection and merge flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your API key.
+OPENAI_API_KEY=sk-your-openai-api-key
+
+# Optional local overrides.
+OPENAI_MODEL=gpt-5.5
+SECRET_KEY=change-this-to-a-random-string
+CURRENCY=USD

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 RUN_LOCAL_INFO.md
+.env
 wine-tracker/.pytest_cache/
 wine-tracker/app/__pycache__/
 wine-tracker/app/data/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ wine-tracker/app/data/
 wine-tracker/tests/__pycache__/
 .DS_Store
 .claude/
-CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.11.0
+
+- **Duplicate detection when adding a wine** - the add-wine flow now detects when a bottle closely matches one already in your cellar and lets you merge it into the existing entry or keep it as a separate row, with a confirmation dialog localised in all 7 languages.
+- **Fix duplicate entry when restocking** - restocking a wine could create a second row instead of increasing the existing bottle's quantity; the restock flow now updates the original entry.
+- **English wine types in `/api/summary`** - the summary feed consumed by Home Assistant REST sensors returned raw German type labels (Rotwein, Weisswein, ...); they are now mapped to English so sensors read consistently regardless of the configured UI language.
+- **Autocomplete on advanced-filter inputs** - the advanced filter's text fields now suggest existing values (region, grape, producer, ...) as you type.
+- **Advanced-filter badge fixes** - the filter button no longer shows an empty blue dot when no filters are active, and the badge count no longer includes stale empty rules.
+- **Mobile advanced-filter polish** - fixed several layout and interaction issues found on mobile while testing the v1.10.0 advanced filter.
+- **Renamed advanced-filter group labels** in all 7 languages for clarity.
+- **Replaced em/en-dashes with plain hyphens app-wide** for consistent rendering across fonts.
+- **Home Assistant dev-addon update script** - added `scripts/update-ha-dev.sh` for one-command updates from GitHub, using `ha apps` with first-install detection.
+- **Local Docker Compose setup** for development.
+- **Point add-on metadata at the ofer8 fork** so the add-on installs and links correctly from this fork.
+
 ## 1.10.0
 
 - **Advanced filter with multiple AND-conditions** - filter the cellar by any combination of fields (type, vintage, region, grape, rating, drink window, location, source, format, ...) in a single popover. Resolves #5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.12.0
+
+- **Extended read-only REST API** - new JSON endpoints for Home Assistant dashboards & automations: `/api/stats` (totals, liters, value, average age/rating, breakdowns by type/region/grape/decade), `/api/drink-window` (wines bucketed ready / too young / past peak, with year-boundary counts for notifications), `/api/wines` (the filterable, sortable collection) and `/api/wines/<id>` (single-wine detail). All use English wine-type labels regardless of UI language. The existing `/api/summary` is unchanged. Resolves the "Extended REST API" roadmap item.
+- **Tests** - added 32 tests for the new API query helpers and routes.
+
 ## 1.11.0
 
 - **Duplicate detection when adding a wine** - the add-wine flow now detects when a bottle closely matches one already in your cellar and lets you merge it into the existing entry or keep it as a separate row, with a confirmation dialog localised in all 7 languages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ A Home Assistant add-on, **Wine Tracker** — a Flask web app (server-rendered J
 - The add-on version is `version:` in `wine-tracker/config.yaml` — **this is the only field Home Assistant uses to decide an update is available.** Changing code without bumping it ships nothing to users.
 - That version string is duplicated in several files that must stay in sync: `wine-tracker/config.yaml`, `wine-tracker/app/app.py` (`APP_VERSION`), `wine-tracker/tests/test_routes.py` (assertion), the version badges in `README.md`, `wine-tracker/README.md`, `wine-tracker/DOCS.md`, and `docs/llms.txt`.
 - Cut releases with `scripts/deploy.sh vX.Y.Z`. It runs tests, bumps every version file, reads a **pre-written** `## X.Y.Z` section from `CHANGELOG.md` (add it first — the script will not generate it), mirrors `CHANGELOG.md` → `wine-tracker/CHANGELOG.md`, commits `Release vX.Y.Z`, tags, pushes, and creates a GitHub Release. The `v*` tag is what triggers the CI image build.
-- The version bump must land on the repository's **default branch** (currently `master`) — that is the branch Home Assistant tracks.
+- The version bump must land on `main`, the repository's **default branch** and the branch Home Assistant tracks.
 
 ## Home Assistant update flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Home Assistant add-on, **Wine Tracker** — a Flask web app (server-rendered Jinja templates + vanilla JS) to track a wine cellar, with AI wine-label recognition and an AI "sommelier" chat across 6 pluggable providers. It is installed as an HA add-on directly from this Git repository and built locally on the user's Home Assistant machine. This repo is a fork of `xenofex7/ha-wine-tracker`.
+
+## Commands
+
+- **Dev server** (needs a repo-root `.venv`):
+  ```
+  python3.12 -m venv .venv && .venv/bin/pip install -r wine-tracker/requirements.txt
+  scripts/run-dev.sh          # serves http://localhost:5050
+  ```
+- **Standalone via Docker:** `docker compose up --build` (root `docker-compose.yaml`, port 5050; configure with env vars / `.env` — `AI_PROVIDER`, `OPENAI_API_KEY`, `LANGUAGE`, `CURRENCY`, `AUTH_ENABLED`).
+- **Tests** (run from repo root; `conftest.py` gives each test a fresh temp DB and default options, so no real data is touched):
+  ```
+  .venv/bin/python -m pytest wine-tracker/tests/
+  ```
+  Single test: `pytest wine-tracker/tests/test_routes.py::TestApiSummary -k test_name`
+- **Python 3.12** is the supported version (Dockerfile + CI). `Pillow` is pinned `<11` and has no wheel for 3.13/3.14 — on a newer local Python, build the venv with 3.12, or override Pillow (`pip install 'Pillow>=11'`) for test runs only.
+- **CI** (`.github/workflows/docker-publish.yml`) runs pytest then builds/pushes the GHCR image — it triggers **only on `v*` tags**, not on branch pushes.
+
+## Architecture
+
+- **Almost everything lives in `wine-tracker/app/app.py`** (~3150 lines): the Flask app is created at the top and every route is inline (no blueprints). Helper modules beside it: `translations.py` (i18n) and `export_import.py` (zip backup/restore).
+- **Startup config flow:** `load_options()` builds the `HA_OPTIONS` dict from `/data/options.json` (which HA generates from the `options:` in `config.yaml`), with environment-variable overrides for standalone Docker. The globals `LANG`, `T` (active translation map) and currency are derived from it once at boot. `init_db()` creates the SQLite schema **and applies in-place column migrations on every boot** — add new columns there.
+- **Data:** SQLite at `$DATA_DIR/wine.db` (`/data/wine-tracker` in Docker, `/share/wine-tracker` under HA). Per-request connection via `get_db()`. Tables: `wines`, `timeline` (audit log of every add/consume/restock/remove/chat action), `chat_sessions` + `chat_messages`, `filter_presets`. Rich fields (`maturity_data`, `taste_profile`, `food_pairings`) are JSON stored in text columns.
+- **AI providers** (`anthropic`, `openai`, `openrouter`, `ollama`, `minimax`, `mistral`): each is a vision call + a chat call, dispatched by `ai_provider` through `_call_chat()`. Only the `anthropic` and `openai` SDKs are dependencies — the others use HTTP / OpenAI-compatible endpoints. Label recognition (`/api/analyze-wine`) prompts the model to return structured JSON about a bottle photo; the sommelier chat (`/api/chat`) injects current-cellar context and, when "edit wines via chat" is enabled, lets the model emit `[ADD_WINE]{...}` action blocks that are parsed and applied after the response.
+- **i18n:** the `TRANSLATIONS` dict in `translations.py` covers **7 languages** (de/en/fr/it/es/pt/nl), default `de`. Any new user-facing string must be added to **all** languages. The `wine_type` template filter maps the German DB labels to the active UI language.
+- **HA ingress:** the app is proxied under a per-session token path. `g.ingress` is read from the `X-Ingress-Path` header and **every template URL must be prefixed with `{{ ingress }}`** — never hardcode absolute URLs.
+- **`/api/summary`** feeds HA REST sensors and deliberately returns **English** wine-type labels regardless of UI language, so sensor values stay stable.
+
+## Versioning & releases
+
+- The add-on version is `version:` in `wine-tracker/config.yaml` — **this is the only field Home Assistant uses to decide an update is available.** Changing code without bumping it ships nothing to users.
+- That version string is duplicated in several files that must stay in sync: `wine-tracker/config.yaml`, `wine-tracker/app/app.py` (`APP_VERSION`), `wine-tracker/tests/test_routes.py` (assertion), the version badges in `README.md`, `wine-tracker/README.md`, `wine-tracker/DOCS.md`, and `docs/llms.txt`.
+- Cut releases with `scripts/deploy.sh vX.Y.Z`. It runs tests, bumps every version file, reads a **pre-written** `## X.Y.Z` section from `CHANGELOG.md` (add it first — the script will not generate it), mirrors `CHANGELOG.md` → `wine-tracker/CHANGELOG.md`, commits `Release vX.Y.Z`, tags, pushes, and creates a GitHub Release. The `v*` tag is what triggers the CI image build.
+- The version bump must land on the repository's **default branch** (currently `master`) — that is the branch Home Assistant tracks.
+
+## Home Assistant update flow
+
+- `config.yaml` has **no `image:` key**, so HA builds the add-on locally from `docker/Dockerfile` on the user's machine. The GHCR image produced by CI is used only by `docker-compose`, **not** by the add-on — so a missing/failed image build does not affect HA updates.
+- An update only surfaces when `config.yaml` `version:` on the tracked branch is greater than the installed version. To make HA notice a fresh release immediately: **Add-on Store → ⋮ → Check for updates** (the Supervisor otherwise polls roughly daily).
+- HA's frontend caches the add-on detail page aggressively: if the add-on list shows "Update available" but the detail page still says up-to-date, hard-refresh the browser or restart the Companion app.
+
+## Conventions
+
+- Use plain hyphens, not em/en-dashes, in user-facing text (see `STYLE_GUIDE.md`).
+- This is a fork — keep the upstream `LICENSE` copyright notice intact.

--- a/README.md
+++ b/README.md
@@ -277,26 +277,77 @@ All data (SQLite database + photos) is stored under `/share/wine-tracker/` - pre
 
 ## Home Assistant Sensor (Optional)
 
+The add-on exposes read-only JSON endpoints for dashboards and automations. All return
+`{"ok": true, ...}` and use **English** wine-type labels regardless of the UI language.
+
+| Endpoint | Returns |
+|----------|---------|
+| `/api/summary` | total bottle count + by-type breakdown (legacy, unchanged) |
+| `/api/stats` | totals, liters, value, average age/rating, breakdowns by type/region/grape/decade |
+| `/api/drink-window` | wines bucketed `ready` / `too_young` / `past_peak` / `unknown`, plus year-boundary counts |
+| `/api/wines` | the collection as JSON, filterable & sortable (`?type=`, `?region=`, `?in_stock=true`, `?sort=year&order=desc`, `?limit=`) |
+| `/api/wines/<id>` | one wine, full detail incl. maturity / taste / pairings |
+
+### Stock & value sensor
+
 ```yaml
 # configuration.yaml
 sensor:
   - platform: rest
-    name: "Wine Stock"
-    resource: "http://localhost:5050/api/summary"
+    name: "Wine Cellar"
+    resource: "http://localhost:5050/api/stats"
     value_template: "{{ value_json.total_bottles }}"
     unit_of_measurement: "bottles"
     json_attributes:
+      - total_liters
+      - total_value
+      - avg_age
+      - avg_rating
       - by_type
     scan_interval: 3600
 ```
 
-This creates a `sensor.wine_stock` entity you can use on dashboards or in automations.
+> **Note:** the `by_type` / `by_region` / `by_grape` / `by_decade` attributes are JSON lists — use a template sensor to extract individual values for a dashboard.
+
+### Drink-window sensor + notification
+
+```yaml
+# configuration.yaml
+sensor:
+  - platform: rest
+    name: "Wines Ready to Drink"
+    resource: "http://localhost:5050/api/drink-window"
+    value_template: "{{ value_json.ready_now }}"
+    unit_of_measurement: "wines"
+    json_attributes:
+      - entering_this_year
+      - leaving_this_year
+    scan_interval: 86400
+
+automation:
+  - alias: "Wine entering its drink window"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.wines_ready_to_drink
+        attribute: entering_this_year
+        above: 0
+    action:
+      - service: notify.notify
+        data:
+          message: >
+            {{ state_attr('sensor.wines_ready_to_drink', 'entering_this_year') }}
+            wine(s) just entered their optimal drinking window.
+```
+
+> **Note (standalone Docker):** when `AUTH_ENABLED=true`, these endpoints require a logged-in
+> session, so an unauthenticated REST sensor receives `401`. In the Home Assistant add-on
+> (the default), access is gated by HA and the sensors work as shown.
 
 ## License
 
 MIT
 
-[version-badge]: https://img.shields.io/badge/version-v1.11.0-blue.svg
+[version-badge]: https://img.shields.io/badge/version-v1.12.0-blue.svg
 [stage-badge]: https://img.shields.io/badge/project%20stage-stable-brightgreen.svg
 [maintained-badge]: https://img.shields.io/badge/maintained-yes-brightgreen.svg
 [license-badge]: https://img.shields.io/badge/license-MIT-green.svg

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A wine cellar tracker for Home Assistant or Docker - manage your entire collecti
 - **Fully responsive** - works great on desktop & mobile
 - **Multi-language** - 7 languages (DE, EN, FR, IT, ES, PT, NL)
 - **HA Ingress** - embedded directly in the Home Assistant sidebar
-- **REST API** at `/api/summary` for HA sensors
+- **REST API** - read-only JSON endpoints (stats, drink window, collection, single wine) for dashboards, sensors & automations
 - **DEV_AUTH mode** - `DEV_AUTH` env var for quick local development without Home Assistant
 - **Backup & restore** - export the whole cellar as a ZIP (JSON + CSV + images) and import it back with duplicate preview
 
@@ -275,18 +275,117 @@ Token cost varies by provider and model - typical analysis is ~2,500 tokens. See
 
 All data (SQLite database + photos) is stored under `/share/wine-tracker/` - preserved across add-on updates, restarts, and HA updates.
 
+## REST API
+
+Wine Tracker exposes read-only JSON endpoints for dashboards, automations, and integrations. They are served on the same host and port as the web UI - `http://<host>:5050` for standalone Docker, or proxied through HA ingress.
+
+**Conventions**
+
+- All endpoints are `GET` and return JSON.
+- The endpoints below use an `{"ok": true, ...}` envelope; errors return `{"ok": false, "error": "..."}` with a matching HTTP status. The legacy `/api/summary` returns its payload directly, without the envelope.
+- Wine `type` is always the **English** canonical label (e.g. `Red Wine`), regardless of the configured UI language, so values stay stable for automations.
+- Auth follows the app: open in the Home Assistant add-on (access gated by HA); in standalone Docker with `AUTH_ENABLED=true`, a request without a valid session receives `401`.
+
+| Endpoint | Purpose |
+|----------|---------|
+| [`GET /api/stats`](#get-apistats) | cellar-wide aggregates |
+| [`GET /api/drink-window`](#get-apidrink-window) | wines bucketed by drinking window |
+| [`GET /api/wines`](#get-apiwines) | filterable / sortable / paginated collection |
+| [`GET /api/wines/<id>`](#get-apiwinesid) | single wine, full detail |
+| [`GET /api/summary`](#get-apisummary-legacy) | bottle count + by-type breakdown (legacy) |
+
+### `GET /api/stats`
+
+Cellar-wide aggregates. Scalar fields are top-level so HA `json_attributes` can read them directly; the `by_*` fields are JSON lists.
+
+| Field | Description |
+|-------|-------------|
+| `total_bottles` | sum of all bottle quantities |
+| `distinct_wines` | number of wine entries (incl. empty placeholders) |
+| `out_of_stock` | entries with quantity 0 |
+| `total_liters` | sum of `quantity x bottle_format` |
+| `total_value` | sum of `quantity x price` |
+| `avg_price` / `avg_age` / `avg_rating` | averages over priced / vintaged / rated wines |
+| `by_type` | `[{ "type", "bottles", "wines" }]` |
+| `by_region` / `by_grape` | `[{ "region"/"grape", "bottles" }]` |
+| `by_decade` | `[{ "decade", "bottles" }]` |
+| `currency` | configured currency code |
+
+```json
+{
+  "ok": true, "currency": "CHF",
+  "total_bottles": 42, "distinct_wines": 18, "out_of_stock": 2,
+  "total_liters": 31.5, "total_value": 1234.5,
+  "avg_price": 29.4, "avg_age": 6.2, "avg_rating": 3.8,
+  "by_type":   [{ "type": "Red Wine", "bottles": 20, "wines": 8 }],
+  "by_region": [{ "region": "Bordeaux", "bottles": 12 }],
+  "by_grape":  [{ "grape": "Merlot", "bottles": 9 }],
+  "by_decade": [{ "decade": 2010, "bottles": 15 }]
+}
+```
+
+### `GET /api/drink-window`
+
+In-stock wines bucketed by drinking window for the current year (`drink_from` / `drink_until` are vintage years).
+
+| Field | Description |
+|-------|-------------|
+| `current_year` | year used for bucketing |
+| `ready_now` | count of wines ready to drink |
+| `entering_this_year` / `leaving_this_year` | wines whose window opens / closes this year |
+| `counts` | `{ "ready", "too_young", "past_peak", "unknown" }` |
+| `ready` / `too_young` / `past_peak` / `unknown` | lists of `{ id, name, year, type, quantity, drink_from, drink_until, location }` |
+
+Buckets (in-stock only): `ready` = `from <= year <= until`, `too_young` = `year < from`, `past_peak` = `year > until`, `unknown` = no window set. One-sided windows (only `from`, or only `until`) are handled.
+
+### `GET /api/wines`
+
+The collection as a filterable, sortable, paginated list of **light** records - every wine field except the large `maturity_data` / `taste_profile` / `food_pairings` blobs (use the detail endpoint for those).
+
+| Query param | Effect |
+|-------------|--------|
+| `type` | English label, e.g. `type=Red Wine` |
+| `region` / `grape` | case-insensitive substring match |
+| `year` | exact vintage |
+| `in_stock` | `true` / `1` / `yes` -> quantity > 0 |
+| `min_rating` | minimum star rating |
+| `sort` | `name` (default), `year`, `rating`, `price`, `added`, `quantity` |
+| `order` | `asc` (default) or `desc` |
+| `limit` / `offset` | pagination (`limit` 1-500) |
+
+Unknown or invalid parameters are ignored - a bad filter never returns `400`.
+
+```
+GET /api/wines?type=Red%20Wine&in_stock=true&sort=year&order=desc&limit=50
+```
+```json
+{ "ok": true, "count": 18, "returned": 18,
+  "wines": [ { "id": 1, "name": "Chateau ...", "year": 2018, "type": "Red Wine",
+               "quantity": 2, "rating": 4, "price": 29.9, "location": "Keller A",
+               "image_path": "/uploads/abc.jpg" } ] }
+```
+
+`count` is the total matching the filters before pagination; `returned` is the page size.
+
+### `GET /api/wines/<id>`
+
+A single wine with full detail, including the parsed `maturity_data`, `taste_profile`, and `food_pairings` objects. Unknown id returns `404`:
+
+```json
+{ "ok": false, "error": "not_found" }
+```
+
+### `GET /api/summary` (legacy)
+
+Unchanged - kept for existing HA sensors. Returns the total bottle count and a by-type breakdown (English labels), without the `ok` envelope.
+
+```json
+{ "total_bottles": 42, "by_type": [{ "type": "Red Wine", "cnt": 8, "total": 20 }] }
+```
+
 ## Home Assistant Sensor (Optional)
 
-The add-on exposes read-only JSON endpoints for dashboards and automations. All return
-`{"ok": true, ...}` and use **English** wine-type labels regardless of the UI language.
-
-| Endpoint | Returns |
-|----------|---------|
-| `/api/summary` | total bottle count + by-type breakdown (legacy, unchanged) |
-| `/api/stats` | totals, liters, value, average age/rating, breakdowns by type/region/grape/decade |
-| `/api/drink-window` | wines bucketed `ready` / `too_young` / `past_peak` / `unknown`, plus year-boundary counts |
-| `/api/wines` | the collection as JSON, filterable & sortable (`?type=`, `?region=`, `?in_stock=true`, `?sort=year&order=desc`, `?limit=`) |
-| `/api/wines/<id>` | one wine, full detail incl. maturity / taste / pairings |
+See the [REST API](#rest-api) reference above for all endpoints, parameters, and response fields. Below are ready-to-use Home Assistant sensor and automation examples.
 
 ### Stock & value sensor
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ This creates a `sensor.wine_stock` entity you can use on dashboards or in automa
 
 MIT
 
-[version-badge]: https://img.shields.io/badge/version-v1.10.0-blue.svg
+[version-badge]: https://img.shields.io/badge/version-v1.11.0-blue.svg
 [stage-badge]: https://img.shields.io/badge/project%20stage-stable-brightgreen.svg
 [maintained-badge]: https://img.shields.io/badge/maintained-yes-brightgreen.svg
 [license-badge]: https://img.shields.io/badge/license-MIT-green.svg

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  wine-tracker:
+    image: ha-wine-tracker:local
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "5050:5050"
+    volumes:
+      - wine-data:/data
+    environment:
+      AUTH_ENABLED: "false"
+      SECRET_KEY: "${SECRET_KEY:-local-dev-secret-change-me}"
+      CURRENCY: "${CURRENCY:-USD}"
+      LANGUAGE: "en"
+      AI_PROVIDER: "openai"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      OPENAI_MODEL: "${OPENAI_MODEL:-gpt-5.5}"
+    restart: unless-stopped
+
+volumes:
+  wine-data:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -356,11 +356,12 @@ See `CLAUDE.md` for full project guidelines (in German).
 
 ## Version History
 
-Current version: **v1.10.0**
+Current version: **v1.11.0**
 
 See `CHANGELOG.md` for the complete version history.
 
 Recent highlights:
+- **v1.11.0** - Duplicate detection on the add flow (merge or keep separate, all 7 languages); restock no longer creates duplicate rows; /api/summary wine types mapped to English for Home Assistant sensors; advanced-filter autocomplete and badge fixes; mobile filter polish; HA dev-addon update script and local Docker Compose setup.
 - **v1.10.0** - Advanced filter with multi-AND conditions and saveable filter presets (resolves #5); Mistral added as a sixth AI provider; mobile chat keyboard fix v2 (CSS --kb-inset, interactive-widget); uniform 38px action buttons; ROADMAP extracted from README.
 - **v1.9.2** - Vivino search rewritten to use the internal JSON API (was broken by Vivino's switch to client-side rendering); smarter term-reduction fallback for regional wines; fixed stats crash with no region data; wider search modal.
 - **v1.9.1** - Fixed mobile keyboard covering chat input on iOS (Visual Viewport API). Chat history sidebar now closes on mobile when starting a new session.

--- a/docs/superpowers/plans/2026-06-21-add-duplicate-detection.md
+++ b/docs/superpowers/plans/2026-06-21-add-duplicate-detection.md
@@ -1,0 +1,560 @@
+# Add-Flow Duplicate Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `POST /add` detect when an incoming wine matches one already in the cellar and let the user merge (bump quantity) or insert separately, instead of always inserting a duplicate.
+
+**Architecture:** Two-phase `/add` driven by a new optional `dup_action` form field. Phase one (no `dup_action`) runs a match query and returns `{ok:false, duplicate:{...}}` without inserting when a match exists. The frontend shows a confirm dialog whose buttons re-POST the same form with `dup_action=merge` (+`dup_target_id`) or `dup_action=separate`. Merge bumps the existing wine's quantity and logs a `restocked` timeline entry. Covers all add paths (AI, Vivino, manual) since they all submit `wineForm` to `/add`.
+
+**Tech Stack:** Python 3.12 / Flask, SQLite, vanilla JS templates (Jinja2), pytest. All Python commands run from `wine-tracker/`.
+
+## Global Constraints
+
+- All Python work runs from the `wine-tracker/` directory.
+- Match rule: `name` (whitespace-trimmed, case-insensitive) **AND** `year` **AND** `bottle_format`. A different vintage or bottle size is NOT a match.
+- Merge changes **quantity only**; all other form fields are ignored on merge.
+- The match query must match regardless of quantity (so empty-bottle placeholders restock).
+- `/edit` and `/duplicate` routes must NOT gain dedup behavior. Only `/add`.
+- Every user-facing string goes through `app/translations.py` for all 7 languages (`de, en, fr, it, es, pt, nl`) — no hardcoded UI text.
+- UI/CSS must reuse existing theme-aware classes (`modal-overlay`, `modal`, `modal-header`, `btn-cancel`, etc.) per `STYLE_GUIDE.md` — no hardcoded theme colors.
+- Restock timeline entry mirrors the existing edit-route pattern (`app/app.py:905-909`): `INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?, "restocked", <added_qty>, datetime.now().isoformat())`.
+
+---
+
+## File Structure
+
+- `wine-tracker/app/app.py` — `/add` route (`app.py:755-811`): add `dup_action` branching, the match query, and the merge branch. Add a small helper `_find_duplicate_wine(db, name, year, bottle_format)`.
+- `wine-tracker/app/translations.py` — new keys in all 7 language dicts.
+- `wine-tracker/app/templates/index.html` — new confirm-dialog modal markup (next to `deleteModal`, ~line 227).
+- `wine-tracker/app/templates/_wine_edit_modal.html` — extend the `wineForm` submit handler (`_wine_edit_modal.html:836-854`) to intercept the duplicate response; add the dialog-button handler functions.
+- `wine-tracker/tests/test_routes.py` — new backend tests.
+
+---
+
+### Task 1: Backend — match helper + two-phase `/add`
+
+**Files:**
+- Modify: `wine-tracker/app/app.py` (route `add()` at `app.py:755-811`; add helper just above it)
+- Test: `wine-tracker/tests/test_routes.py`
+
+**Interfaces:**
+- Consumes: `get_db()`, `wine_json(id)`, `stats_json()`, `is_ajax()`, `datetime`, `date` (all already imported/defined in `app.py`).
+- Produces:
+  - `_find_duplicate_wine(db, name, year, bottle_format) -> sqlite3.Row | None` — returns the most-recent matching wine row or `None`.
+  - `POST /add` now reads form field `dup_action` (`""` | `"separate"` | `"merge"`) and `dup_target_id` (int, required when `dup_action="merge"`).
+  - Phase-one duplicate response shape: `{"ok": false, "duplicate": {"id", "name", "year", "bottle_format", "quantity", "location"}}` (HTTP 200).
+  - Merge success response: `{"ok": true, "wine": <wine_json>, "stats": <stats_json>}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `wine-tracker/tests/test_routes.py`:
+
+```python
+def _add_wine(client, **overrides):
+    data = {
+        "name": "Château Test", "year": "2018", "type": "Rotwein",
+        "region": "Bordeaux, FR", "quantity": "1", "rating": "0",
+        "bottle_format": "0.75",
+    }
+    data.update(overrides)
+    return client.post("/add", data=data,
+                       headers={"X-Requested-With": "XMLHttpRequest"})
+
+
+def test_add_no_existing_inserts_normally(client, db):
+    resp = _add_wine(client, quantity="2")
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    rows = db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()
+    assert rows["c"] == 1
+
+
+def test_add_matching_wine_returns_duplicate_without_inserting(client, db):
+    _add_wine(client, quantity="3")
+    resp = _add_wine(client, quantity="1")
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Château Test"
+    assert body["duplicate"]["year"] == 2018
+    assert body["duplicate"]["quantity"] == 3
+    # Still only ONE row — phase one must not insert
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_bumps_quantity_and_logs_restock(client, db):
+    first = json.loads(_add_wine(client, quantity="3").data)
+    target_id = first["wine"]["id"]
+    resp = _add_wine(client, quantity="2", dup_action="merge",
+                     dup_target_id=str(target_id))
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 5
+    restock = db.execute(
+        "SELECT quantity FROM timeline WHERE wine_id=? AND action='restocked'",
+        (target_id,)).fetchone()
+    assert restock["quantity"] == 2
+
+
+def test_add_separate_inserts_second_row(client, db):
+    _add_wine(client, quantity="1")
+    resp = _add_wine(client, quantity="1", dup_action="separate")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_match_is_case_and_whitespace_insensitive(client, db):
+    _add_wine(client, name="Château Test", quantity="1")
+    resp = _add_wine(client, name="  château test ", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_different_year_is_not_a_match(client, db):
+    _add_wine(client, year="2018", quantity="1")
+    resp = _add_wine(client, year="2019", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_different_bottle_format_is_not_a_match(client, db):
+    _add_wine(client, bottle_format="0.75", quantity="1")
+    resp = _add_wine(client, bottle_format="1.5", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_null_vintage_wines_match(client, db):
+    _add_wine(client, year="", quantity="1")
+    resp = _add_wine(client, year="", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_restocks_empty_bottle(client, db):
+    first = json.loads(_add_wine(client, quantity="1").data)
+    target_id = first["wine"]["id"]
+    db.execute("UPDATE wines SET quantity=0 WHERE id=?", (target_id,))
+    db.commit()
+    _add_wine(client, quantity="2", dup_action="merge", dup_target_id=str(target_id))
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 2
+```
+
+Make sure `import json` is present at the top of `test_routes.py` (it is used elsewhere; add if missing).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py -k "test_add_no_existing or test_add_matching or test_add_merge or test_add_separate or test_add_match_is_case or test_add_different or test_add_null or test_add_merge_restocks" -v`
+Expected: FAIL (new behavior not implemented — e.g. `test_add_matching_wine_returns_duplicate_without_inserting` fails because `ok` is `True`).
+
+- [ ] **Step 3: Add the `_find_duplicate_wine` helper**
+
+Insert directly above `@app.route("/add", methods=["POST"])` (currently `app.py:755`):
+
+```python
+def _find_duplicate_wine(db, name, year, bottle_format):
+    """Return the most-recent wine matching name (trimmed, case-insensitive),
+    year, and bottle_format -- regardless of quantity -- or None."""
+    return db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location
+           FROM wines
+           WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+             AND year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC
+           LIMIT 1""",
+        (name, year, bottle_format),
+    ).fetchone()
+```
+
+- [ ] **Step 4: Rewrite the `add()` route to be two-phase**
+
+Replace the body of `add()` (`app.py:756-811`) with:
+
+```python
+def add():
+    db = get_db()
+    dup_action = request.form.get("dup_action", "").strip()
+
+    # Normalize the same values the matcher and INSERT use.
+    name = request.form["name"].strip()
+    year = request.form.get("year") or None
+    bottle_format_raw = request.form.get("bottle_format", "").strip()
+    bottle_format = float(bottle_format_raw) if bottle_format_raw else 0.75
+    qty = int(request.form.get("quantity", 1))
+
+    # ── Merge: bump an existing wine's quantity, log a restock ──
+    if dup_action == "merge":
+        target_id = request.form.get("dup_target_id", "").strip()
+        target = db.execute(
+            "SELECT id, quantity FROM wines WHERE id=?", (target_id,)
+        ).fetchone() if target_id else None
+        if not target:
+            return jsonify({"ok": False, "error": "merge_target_missing"}), 400
+        db.execute(
+            "UPDATE wines SET quantity = quantity + ? WHERE id=?",
+            (qty, target["id"]),
+        )
+        db.execute(
+            "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+            (target["id"], "restocked", qty, datetime.now().isoformat()),
+        )
+        db.commit()
+        if is_ajax():
+            return jsonify({"ok": True, "wine": wine_json(target["id"]), "stats": stats_json()})
+        return redirect(g.get("ingress", "") + url_for("index"))
+
+    # ── Phase one: unless the user already chose "separate", look for a dup ──
+    if dup_action != "separate":
+        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        if existing:
+            return jsonify({"ok": False, "duplicate": {
+                "id": existing["id"],
+                "name": existing["name"],
+                "year": existing["year"],
+                "bottle_format": existing["bottle_format"],
+                "quantity": existing["quantity"],
+                "location": existing["location"],
+            }})
+
+    # ── Insert (no match, or user chose "separate") ──
+    image = save_image(request.files.get("image"))
+    # If no new image uploaded but AI already saved one, use that
+    if not image:
+        ai_img = request.form.get("ai_image", "").strip()
+        if ai_img and os.path.isfile(os.path.join(UPLOAD_DIR, ai_img)):
+            image = ai_img
+    price_raw = request.form.get("price", "").strip()
+    vivino_raw = request.form.get("vivino_id", "").strip()
+    maturity_data_raw = request.form.get("maturity_data", "").strip() or None
+    taste_profile_raw = request.form.get("taste_profile", "").strip() or None
+    food_pairings_raw = request.form.get("food_pairings", "").strip() or None
+    cur = db.execute(
+        """INSERT INTO wines
+           (name, year, type, region, quantity, rating, notes, image, added,
+            purchased_at, price, drink_from, drink_until, location, grape, vivino_id, bottle_format,
+            maturity_data, taste_profile, food_pairings)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            name,
+            year,
+            request.form.get("type"),
+            request.form.get("region", "").strip(),
+            qty,
+            int(request.form.get("rating", 0)),
+            request.form.get("notes", "").strip(),
+            image,
+            str(date.today()),
+            request.form.get("purchased_at", "").strip() or None,
+            float(price_raw) if price_raw else None,
+            request.form.get("drink_from") or None,
+            request.form.get("drink_until") or None,
+            request.form.get("location", "").strip() or None,
+            request.form.get("grape", "").strip() or None,
+            int(vivino_raw) if vivino_raw else None,
+            bottle_format,
+            maturity_data_raw,
+            taste_profile_raw,
+            food_pairings_raw,
+        ),
+    )
+    db.commit()
+    new_id = cur.lastrowid
+    db.execute(
+        "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+        (new_id, "added", qty, datetime.now().isoformat()),
+    )
+    db.commit()
+    if is_ajax():
+        return jsonify({"ok": True, "wine": wine_json(new_id), "stats": stats_json()})
+    path = g.get("ingress", "") + url_for("index") + f"?new={new_id}"
+    return redirect(path)
+```
+
+Note: this preserves the original insert logic verbatim except that `name`, `year`, `bottle_format`, and `qty` are now computed once at the top and reused.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py -k "test_add_no_existing or test_add_matching or test_add_merge or test_add_separate or test_add_match_is_case or test_add_different or test_add_null or test_add_merge_restocks" -v`
+Expected: PASS (all 9).
+
+- [ ] **Step 6: Run the full suite to check for regressions**
+
+Run: `cd wine-tracker && pytest tests/ -q`
+Expected: PASS (pre-existing add tests still green; the `sample_wine` fixture adds a unique wine so it is unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add wine-tracker/app/app.py wine-tracker/tests/test_routes.py
+git commit -m "Add duplicate detection to /add route (merge/separate/detect)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Translations for the confirm dialog
+
+**Files:**
+- Modify: `wine-tracker/app/translations.py` (all 7 language dicts)
+- Test: `wine-tracker/tests/test_routes.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: 5 new keys in every language dict: `dup_detect_title`, `dup_detect_body`, `dup_detect_merge`, `dup_detect_separate`, `dup_detect_cancel`. `dup_detect_body` contains the placeholder tokens `{qty}`, `{name}`, `{year}`, `{format}`, `{location}` which the frontend substitutes; `dup_detect_merge` contains `{n}` for the resulting quantity.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `wine-tracker/tests/test_routes.py`:
+
+```python
+def test_translations_have_dup_detect_keys():
+    import translations
+    keys = ["dup_detect_title", "dup_detect_body", "dup_detect_merge",
+            "dup_detect_separate", "dup_detect_cancel"]
+    for lang, d in translations.TRANSLATIONS.items():
+        for k in keys:
+            assert k in d, f"{lang} missing {k}"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py::test_translations_have_dup_detect_keys -v`
+Expected: FAIL with AssertionError "de missing dup_detect_title".
+
+- [ ] **Step 3: Add the keys to each language dict**
+
+In `app/translations.py`, add these entries inside each language block (place them near the existing `dup_*` / delete keys for consistency). Use the exact values below.
+
+German (`"de"`):
+```python
+    "dup_detect_title": "Wein bereits vorhanden",
+    "dup_detect_body": "Du hast bereits {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Zum vorhandenen hinzufügen (jetzt {n})",
+    "dup_detect_separate": "Als separaten Eintrag hinzufügen",
+    "dup_detect_cancel": "Abbrechen",
+```
+
+English (`"en"`):
+```python
+    "dup_detect_title": "Wine already in cellar",
+    "dup_detect_body": "You already have {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Add to existing (now {n})",
+    "dup_detect_separate": "Add as separate entry",
+    "dup_detect_cancel": "Cancel",
+```
+
+French (`"fr"`):
+```python
+    "dup_detect_title": "Vin déjà en cave",
+    "dup_detect_body": "Vous avez déjà {qty}x {name} {year} ({format}l) dans {location}.",
+    "dup_detect_merge": "Ajouter à l'existant (désormais {n})",
+    "dup_detect_separate": "Ajouter comme entrée séparée",
+    "dup_detect_cancel": "Annuler",
+```
+
+Italian (`"it"`):
+```python
+    "dup_detect_title": "Vino già in cantina",
+    "dup_detect_body": "Hai già {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aggiungi all'esistente (ora {n})",
+    "dup_detect_separate": "Aggiungi come voce separata",
+    "dup_detect_cancel": "Annulla",
+```
+
+Spanish (`"es"`):
+```python
+    "dup_detect_title": "Vino ya en la bodega",
+    "dup_detect_body": "Ya tienes {qty}x {name} {year} ({format}l) en {location}.",
+    "dup_detect_merge": "Añadir al existente (ahora {n})",
+    "dup_detect_separate": "Añadir como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+```
+
+Portuguese (`"pt"`):
+```python
+    "dup_detect_title": "Vinho já na adega",
+    "dup_detect_body": "Você já tem {qty}x {name} {year} ({format}l) em {location}.",
+    "dup_detect_merge": "Adicionar ao existente (agora {n})",
+    "dup_detect_separate": "Adicionar como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+```
+
+Dutch (`"nl"`):
+```python
+    "dup_detect_title": "Wijn al in kelder",
+    "dup_detect_body": "Je hebt al {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aan bestaande toevoegen (nu {n})",
+    "dup_detect_separate": "Als aparte vermelding toevoegen",
+    "dup_detect_cancel": "Annuleren",
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cd wine-tracker && pytest tests/test_routes.py::test_translations_have_dup_detect_keys -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wine-tracker/app/translations.py wine-tracker/tests/test_routes.py
+git commit -m "Add dup-detect dialog strings for all 7 languages
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Frontend — confirm dialog markup + submit interception
+
+**Files:**
+- Modify: `wine-tracker/app/templates/index.html` (add modal markup after `deleteModal`, ~line 227)
+- Modify: `wine-tracker/app/templates/_wine_edit_modal.html` (submit handler at lines 836-854; add handler functions)
+
+**Interfaces:**
+- Consumes: backend phase-one response `{ok:false, duplicate:{id,name,year,bottle_format,quantity,location}}`; `window.T` translation dict; existing `openModal(id)` / `closeModal(id)` (`index.html:692,711`); existing `window._onWineSaved(data)` success path.
+- Produces: a `#dupDetectModal` overlay; JS functions `showDupDetectDialog(form, dup)`, `dupMerge()`, `dupSeparate()` on `window`.
+
+- [ ] **Step 1: Add the dialog markup**
+
+In `index.html`, immediately after the `deleteModal` block (after line 227, before the WINE VIEW MODAL comment), add:
+
+```html
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay" id="dupDetectModal">
+  <div class="modal" style="max-width:380px">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
+      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
+```
+
+(Reuses existing theme-aware classes `modal-overlay`, `modal`, `modal-header`, `delete-confirm-body`, `delete-confirm-actions`, `btn-submit` (the primary Save-button class, `_wine_edit_modal.html:145` / `style.css:870`), `btn-cancel`.)
+
+- [ ] **Step 2: Intercept the duplicate response in the submit handler**
+
+In `_wine_edit_modal.html`, replace the submit handler body (lines 836-854) with:
+
+```javascript
+var _dupPendingForm = null;
+var _dupPending = null;
+
+document.getElementById('wineForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  var form = this;
+  submitWineForm(form, null);
+});
+
+function submitWineForm(form, dupAction, targetId) {
+  var fd = new FormData(form);
+  if (dupAction) {
+    fd.set('dup_action', dupAction);
+    if (targetId != null) fd.set('dup_target_id', targetId);
+  }
+  fetch(form.action, {
+    method: 'POST', body: fd,
+    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    // Duplicate detected on an /add submit -> ask the user.
+    if (!data.ok && data.duplicate) {
+      showDupDetectDialog(form, data.duplicate);
+      return;
+    }
+    if (!data.ok) return;
+    closeModal('dupDetectModal');
+    closeModal('wineModal');
+    if (typeof window._onWineSaved === 'function') {
+      window._onWineSaved(data);
+    } else {
+      window.location.reload();
+    }
+  });
+}
+
+function showDupDetectDialog(form, dup) {
+  _dupPendingForm = form;
+  _dupPending = dup;
+  var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
+  var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
+  var body = (window.T.dup_detect_body || '')
+    .replace('{qty}', dup.quantity)
+    .replace('{name}', dup.name || '')
+    .replace('{year}', dup.year || '')
+    .replace('{format}', fmt)
+    .replace('{location}', dup.location || '-');
+  document.getElementById('dupDetectBody').textContent = body;
+  document.getElementById('dupMergeBtn').textContent =
+    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  openModal('dupDetectModal');
+}
+
+function dupMerge() {
+  if (_dupPendingForm && _dupPending) {
+    submitWineForm(_dupPendingForm, 'merge', _dupPending.id);
+  }
+}
+
+function dupSeparate() {
+  if (_dupPendingForm) {
+    submitWineForm(_dupPendingForm, 'separate');
+  }
+}
+```
+
+Note: `closeModal('dupDetectModal')` is called on success so the dialog closes after a merge/separate completes. The `dupDetectModal` lives in `index.html` and `openModal`/`closeModal` are global, so they are reachable from this included template.
+
+- [ ] **Step 3: Manual verification (no automated frontend test in this repo)**
+
+Run the dev server and exercise the flow:
+
+```bash
+cd /Users/ofer/conductor/workspaces/ha-wine-tracker/riyadh && ./scripts/run-dev.sh
+```
+
+Then in the browser at http://localhost:5050:
+1. Add a wine "Verify Wine" 2018, 0.75l, qty 2 → it appears.
+2. Add "Verify Wine" 2018, 0.75l, qty 1 again → the duplicate dialog appears showing "You already have 2x Verify Wine 2018 (0.75l) in ...", merge button reads "Add to existing (now 3)".
+3. Click merge → card quantity becomes 3, no second card.
+4. Repeat add, click "Add as separate entry" → a second card appears.
+5. Add a different vintage 2019 → inserts directly, no dialog.
+
+Expected: all five behave as described. Stop the server with Ctrl-C.
+
+- [ ] **Step 4: Run the full test suite (ensure backend still green)**
+
+Run: `cd wine-tracker && pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wine-tracker/app/templates/index.html wine-tracker/app/templates/_wine_edit_modal.html
+git commit -m "Add duplicate-detect confirm dialog to the add flow
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** match rule (Task 1 helper + tests), two-phase `/add` (Task 1), merge = quantity only + restock timeline (Task 1), empty-bottle restock (Task 1 test), all 7 languages (Task 2), three-button dialog reusing theme classes (Task 3), `/edit` & `/duplicate` untouched (only `add()` changed). All covered.
+- **Edit route unaffected:** the new `submitWineForm` is shared by add and edit, but `dup_action` is only ever sent by the dialog buttons, and the backend only inspects `dup_action` in `/add`. `/edit` ignores unknown form fields. Edit submits therefore behave exactly as before.
+- **Placeholder scan:** none.
+- **Type consistency:** `_find_duplicate_wine` returns a Row consumed only inside `add()`; frontend `dup.id`/`dup.quantity` match the JSON keys produced in Task 1; `{n}`/`{qty}`/`{format}` tokens in Task 2 match the `.replace(...)` calls in Task 3.
+- **Button class verified:** the primary Save button uses `btn-submit` (`_wine_edit_modal.html:145`, `style.css:870`); the dialog's merge button reuses it.

--- a/docs/superpowers/plans/2026-06-21-ha-rest-api.md
+++ b/docs/superpowers/plans/2026-06-21-ha-rest-api.md
@@ -1,0 +1,1049 @@
+# Extended HA Read-Only REST API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four read-only JSON endpoints for Home Assistant — `/api/stats`, `/api/drink-window`, `/api/wines` (filterable list), `/api/wines/<id>` (detail).
+
+**Architecture:** All query/aggregation logic lives in a new pure module `wine-tracker/app/api_queries.py` (no Flask imports — every function takes an open `sqlite3` connection and returns plain dicts/lists, so it's unit-testable without HTTP). `app.py` gains four thin route handlers that call those functions and wrap the result in `jsonify`. No schema change, no new dependencies.
+
+**Tech Stack:** Python 3 / Flask 3 / SQLite (`sqlite3` stdlib) / pytest.
+
+## Global Constraints
+
+- **Response envelope:** success `{"ok": true, ...}`; error `{"ok": false, "error": "..."}` + HTTP status. Routes use `jsonify(ok=True, **data)`.
+- **Wine `type` is always the English canonical label** via `TRANSLATIONS["en"].get(f"wine_type_{raw}", raw)`. Stored keys: `Rotwein/Weisswein/Rosé/Schaumwein/Dessertwein/Likörwein/Anderes` → `Red Wine/White Wine/Rosé/Sparkling Wine/Dessert Wine/Fortified Wine/Other`. The raw value is **not** also returned.
+- **Lenient query params:** unknown/uninterpretable params fall back to defaults — never return 400 for a bad filter/sort.
+- **Auth:** no new mechanism. The endpoints inherit `check_auth` (`app.py:345`), exactly like `/api/summary`. All four are GET, so `check_readonly` never blocks them.
+- **Flat `/api/` prefix** (no versioning). Do **not** modify `/api/summary`, `/api/wine/<id>`, `/api/timeline`, or the `/stats` page.
+- **Commit style:** plain imperative subject (matches repo history, no `feat:` prefix), end every commit message with the trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **Run tests from** the `wine-tracker/` directory: `cd wine-tracker && python -m pytest`.
+
+---
+
+### Task 1: `api_queries` module — `type_en`, `resolve_type_filter`, `serialize_wine`
+
+These three helpers are the shared building blocks every endpoint uses. This task also creates the new test file and its insert helper.
+
+**Files:**
+- Create: `wine-tracker/app/api_queries.py`
+- Create: `wine-tracker/tests/test_api_ha.py`
+
+**Interfaces:**
+- Consumes: `from translations import TRANSLATIONS` (existing module).
+- Produces:
+  - `type_en(raw: str | None) -> str | None`
+  - `resolve_type_filter(value: str | None) -> str | None`
+  - `serialize_wine(row: sqlite3.Row, full: bool = False) -> dict`
+  - Test helper `_insert(db, **fields) -> int` (in `test_api_ha.py`, reused by later tasks).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `wine-tracker/tests/test_api_ha.py`:
+
+```python
+"""Tests for the read-only Home Assistant REST API (api_queries + routes)."""
+import json
+
+import api_queries
+
+
+# ── shared insert helper ───────────────────────────────────────────────────────
+_WINE_DEFAULTS = {
+    "name": "Wine", "year": None, "type": None, "region": None,
+    "quantity": 1, "rating": 0, "notes": None, "image": None,
+    "added": "2026-01-01", "purchased_at": None, "price": None,
+    "drink_from": None, "drink_until": None, "location": None,
+    "grape": None, "vivino_id": None, "bottle_format": 0.75,
+    "maturity_data": None, "taste_profile": None, "food_pairings": None,
+}
+
+
+def _insert(db, **fields):
+    """Insert one wines row, commit, return its id. Unspecified columns use defaults."""
+    cols = dict(_WINE_DEFAULTS)
+    cols.update(fields)
+    names = ",".join(cols)
+    placeholders = ",".join("?" * len(cols))
+    cur = db.execute(f"INSERT INTO wines ({names}) VALUES ({placeholders})", tuple(cols.values()))
+    db.commit()
+    return cur.lastrowid
+
+
+def _get_row(db, wine_id):
+    return db.execute("SELECT * FROM wines WHERE id = ?", (wine_id,)).fetchone()
+
+
+# ── type_en ─────────────────────────────────────────────────────────────────────
+def test_type_en_translates_known_keys():
+    assert api_queries.type_en("Rotwein") == "Red Wine"
+    assert api_queries.type_en("Weisswein") == "White Wine"
+    assert api_queries.type_en("Anderes") == "Other"
+
+
+def test_type_en_passes_through_unknown_and_none():
+    assert api_queries.type_en("Glühwein") == "Glühwein"
+    assert api_queries.type_en(None) is None
+    assert api_queries.type_en("") == ""
+
+
+# ── resolve_type_filter ─────────────────────────────────────────────────────────
+def test_resolve_type_filter_maps_english_to_key():
+    assert api_queries.resolve_type_filter("Red Wine") == "Rotwein"
+    assert api_queries.resolve_type_filter("red wine") == "Rotwein"   # case-insensitive
+    assert api_queries.resolve_type_filter("Other") == "Anderes"
+
+
+def test_resolve_type_filter_passthrough_unknown():
+    assert api_queries.resolve_type_filter("Rotwein") == "Rotwein"    # raw key still works
+    assert api_queries.resolve_type_filter("Foo") == "Foo"
+    assert api_queries.resolve_type_filter(None) is None
+
+
+# ── serialize_wine ──────────────────────────────────────────────────────────────
+def test_serialize_wine_light_omits_ai_blobs(db):
+    wid = _insert(db, name="A", type="Rotwein", image="x.jpg",
+                  maturity_data='{"k": 1}', taste_profile='{"body": 2}',
+                  food_pairings='["cheese"]')
+    out = api_queries.serialize_wine(_get_row(db, wid), full=False)
+    assert out["type"] == "Red Wine"
+    assert out["image_path"] == "/uploads/x.jpg"
+    assert "maturity_data" not in out
+    assert "taste_profile" not in out
+    assert "food_pairings" not in out
+
+
+def test_serialize_wine_full_parses_ai_blobs(db):
+    wid = _insert(db, name="A", type="Weisswein",
+                  maturity_data='{"k": 1}', food_pairings='["cheese"]')
+    out = api_queries.serialize_wine(_get_row(db, wid), full=True)
+    assert out["type"] == "White Wine"
+    assert out["maturity_data"] == {"k": 1}        # parsed to object, not string
+    assert out["food_pairings"] == ["cheese"]
+
+
+def test_serialize_wine_image_path_none_when_no_image(db):
+    wid = _insert(db, name="A", image=None)
+    out = api_queries.serialize_wine(_get_row(db, wid))
+    assert out["image_path"] is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -v`
+Expected: collection/import error — `ModuleNotFoundError: No module named 'api_queries'` (the module doesn't exist yet).
+
+- [ ] **Step 3: Create the `api_queries` module**
+
+Create `wine-tracker/app/api_queries.py`:
+
+```python
+"""Pure query/aggregation helpers for the read-only Home Assistant REST API.
+
+No Flask imports — every function takes an open sqlite3 connection (with a
+sqlite3.Row row_factory) and returns plain dict/list data, so they are
+unit-testable without an HTTP layer. The routes in app.py wrap these in jsonify().
+"""
+import json
+
+from translations import TRANSLATIONS
+
+_EN = TRANSLATIONS["en"]
+
+# Reverse lookup: lower-cased English label -> stored key, e.g. "red wine" -> "Rotwein".
+_EN_TO_KEY = {
+    label.lower(): key[len("wine_type_"):]
+    for key, label in _EN.items()
+    if key.startswith("wine_type_")
+}
+
+_AI_JSON_FIELDS = ("maturity_data", "taste_profile", "food_pairings")
+
+
+def type_en(raw):
+    """Translate a stored wine-type key ('Rotwein') to its English label ('Red Wine').
+
+    Unknown or falsy values are returned unchanged (None stays None, "" stays "").
+    """
+    if not raw:
+        return raw
+    return _EN.get(f"wine_type_{raw}", raw)
+
+
+def resolve_type_filter(value):
+    """Map an English type label back to its stored key for filtering.
+
+    'Red Wine' -> 'Rotwein' (case-insensitive). Unknown values pass through
+    unchanged, so raw stored keys still work as a filter.
+    """
+    if not value:
+        return value
+    return _EN_TO_KEY.get(value.strip().lower(), value)
+
+
+def serialize_wine(row, full=False):
+    """Convert a wines row (sqlite3.Row) to a JSON-ready dict.
+
+    - `type` is replaced with its English label.
+    - `image_path` is added ('/uploads/<image>' or None).
+    - full=True: the three AI JSON-text columns are parsed into objects.
+    - full=False: those three columns are omitted entirely.
+    """
+    d = dict(row)
+    d["type"] = type_en(d.get("type"))
+    image = d.get("image")
+    d["image_path"] = f"/uploads/{image}" if image else None
+    if full:
+        for key in _AI_JSON_FIELDS:
+            raw = d.get(key)
+            if raw:
+                try:
+                    d[key] = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    d[key] = None
+    else:
+        for key in _AI_JSON_FIELDS:
+            d.pop(key, None)
+    return d
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -v`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wine-tracker/app/api_queries.py wine-tracker/tests/test_api_ha.py
+git commit -m "Add api_queries module with type + serialize helpers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `compute_stats` + `GET /api/stats`
+
+**Files:**
+- Modify: `wine-tracker/app/api_queries.py` (add `compute_stats`)
+- Modify: `wine-tracker/app/app.py` (add `import api_queries` near line 18; add route before the `# ── Main ──` comment, ~line 3150)
+- Modify: `wine-tracker/tests/test_api_ha.py` (add stats tests)
+
+**Interfaces:**
+- Consumes: `type_en` (Task 1).
+- Produces: `compute_stats(db, current_year: int) -> dict` with keys `total_bottles, distinct_wines, out_of_stock, total_liters, total_value, avg_price, avg_age, avg_rating, by_type, by_region, by_grape, by_decade`. The route adds `currency` and `ok`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `wine-tracker/tests/test_api_ha.py`:
+
+```python
+# ── compute_stats / /api/stats ──────────────────────────────────────────────────
+def test_stats_empty_db(client):
+    resp = client.get("/api/stats")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert data["total_bottles"] == 0
+    assert data["distinct_wines"] == 0
+    assert data["by_type"] == []
+    assert data["by_region"] == []
+    assert data["currency"] == "CHF"
+
+
+def test_stats_aggregates(db):
+    _insert(db, name="A", type="Rotwein", region="Bordeaux", grape="Merlot",
+            quantity=2, price=10.0, year=2018, bottle_format=0.75, rating=4)
+    _insert(db, name="B", type="Rotwein", region="Bordeaux", grape="Merlot",
+            quantity=3, price=20.0, year=2012, bottle_format=1.5, rating=2)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["total_bottles"] == 5
+    assert s["distinct_wines"] == 2
+    assert s["total_liters"] == round(2 * 0.75 + 3 * 1.5, 2)   # 6.0
+    assert s["total_value"] == round(2 * 10.0 + 3 * 20.0, 2)   # 80.0
+    assert s["avg_age"] == round(((2026 - 2018) + (2026 - 2012)) / 2, 1)  # 11.0
+    assert s["avg_rating"] == 3.0
+
+
+def test_stats_by_type_uses_english(db):
+    _insert(db, name="A", type="Rotwein", quantity=2)
+    _insert(db, name="B", type="Weisswein", quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    types = {row["type"]: row["bottles"] for row in s["by_type"]}
+    assert types == {"Red Wine": 2, "White Wine": 1}
+
+
+def test_stats_excludes_empty_dimensions(db):
+    _insert(db, name="A", type=None, region="", grape=None, quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["by_type"] == []
+    assert s["by_region"] == []
+    assert s["by_grape"] == []
+
+
+def test_stats_by_decade(db):
+    _insert(db, name="A", year=2018, quantity=1)
+    _insert(db, name="B", year=2012, quantity=2)
+    _insert(db, name="C", year=2003, quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    decades = {row["decade"]: row["bottles"] for row in s["by_decade"]}
+    assert decades == {2010: 3, 2000: 1}
+
+
+def test_stats_out_of_stock(db):
+    _insert(db, name="A", quantity=0)
+    _insert(db, name="B", quantity=2)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["out_of_stock"] == 1
+    assert s["total_bottles"] == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k stats -v`
+Expected: FAIL — `AttributeError: module 'api_queries' has no attribute 'compute_stats'` (and the route test 404s).
+
+- [ ] **Step 3a: Add `compute_stats` to `api_queries.py`**
+
+Append to `wine-tracker/app/api_queries.py`:
+
+```python
+def compute_stats(db, current_year):
+    """Aggregate cellar statistics. Returns a flat dict (no envelope, no currency)."""
+    totals = db.execute(
+        "SELECT COALESCE(SUM(quantity), 0) AS bottles, COUNT(*) AS wines FROM wines"
+    ).fetchone()
+    out_of_stock = db.execute(
+        "SELECT COUNT(*) FROM wines WHERE quantity = 0"
+    ).fetchone()[0]
+    liters = db.execute(
+        "SELECT COALESCE(SUM(quantity * COALESCE(bottle_format, 0.75)), 0) FROM wines"
+    ).fetchone()[0]
+    value = db.execute(
+        "SELECT COALESCE(SUM(quantity * price), 0) AS total, AVG(price) AS avg "
+        "FROM wines WHERE price IS NOT NULL AND price > 0"
+    ).fetchone()
+    avg_age = db.execute(
+        "SELECT AVG(? - year) FROM wines WHERE year IS NOT NULL AND year > 0",
+        (current_year,),
+    ).fetchone()[0]
+    avg_rating = db.execute(
+        "SELECT AVG(rating) FROM wines WHERE rating > 0"
+    ).fetchone()[0]
+
+    by_type = [
+        {"type": type_en(r["type"]), "bottles": r["bottles"], "wines": r["wines"]}
+        for r in db.execute(
+            "SELECT type, COALESCE(SUM(quantity), 0) AS bottles, COUNT(*) AS wines "
+            "FROM wines WHERE type IS NOT NULL AND type != '' "
+            "GROUP BY type ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_region = [
+        {"region": r["region"], "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT region, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE region IS NOT NULL AND region != '' "
+            "GROUP BY region ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_grape = [
+        {"grape": r["grape"], "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT grape, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE grape IS NOT NULL AND grape != '' "
+            "GROUP BY grape ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_decade = [
+        {"decade": int(r["decade"]), "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT (year / 10) * 10 AS decade, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE year IS NOT NULL AND year > 0 "
+            "GROUP BY decade ORDER BY decade ASC"
+        ).fetchall()
+    ]
+
+    return {
+        "total_bottles": totals["bottles"],
+        "distinct_wines": totals["wines"],
+        "out_of_stock": out_of_stock,
+        "total_liters": round(liters, 2),
+        "total_value": round(value["total"], 2),
+        "avg_price": round(value["avg"], 2) if value["avg"] is not None else 0.0,
+        "avg_age": round(avg_age, 1) if avg_age is not None else 0.0,
+        "avg_rating": round(avg_rating, 1) if avg_rating is not None else 0.0,
+        "by_type": by_type,
+        "by_region": by_region,
+        "by_grape": by_grape,
+        "by_decade": by_decade,
+    }
+```
+
+- [ ] **Step 3b: Wire the route into `app.py`**
+
+Add the import. Find (`app.py:15-18`):
+
+```python
+from export_import import (
+    build_export_zip, export_filename,
+    parse_import_file, match_wines, apply_import, ImportError as WineImportError,
+)
+```
+
+Add immediately after it:
+
+```python
+import api_queries
+```
+
+Then add the route immediately **before** the `# ── Main ──` section comment (`app.py:~3150`, right after the `api_summary` function):
+
+```python
+@app.route("/api/stats")
+def api_stats():
+    db = get_db()
+    data = api_queries.compute_stats(db, datetime.now().year)
+    data["currency"] = HA_OPTIONS.get("currency", "CHF")
+    return jsonify(ok=True, **data)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k stats -v`
+Expected: PASS (6 stats tests).
+
+- [ ] **Step 5: Run the full test file**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -v`
+Expected: PASS (14 tests total so far).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wine-tracker/app/api_queries.py wine-tracker/app/app.py wine-tracker/tests/test_api_ha.py
+git commit -m "Add GET /api/stats endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `compute_drink_window` + `GET /api/drink-window`
+
+**Files:**
+- Modify: `wine-tracker/app/api_queries.py` (add `_dw_entry`, `compute_drink_window`)
+- Modify: `wine-tracker/app/app.py` (add route before `# ── Main ──`)
+- Modify: `wine-tracker/tests/test_api_ha.py` (add drink-window tests)
+
+**Interfaces:**
+- Consumes: `type_en` (Task 1).
+- Produces: `compute_drink_window(db, current_year: int) -> dict` with keys `current_year, ready_now, entering_this_year, leaving_this_year, counts, ready, too_young, past_peak, unknown`. Each bucket is a list of entries `{id, name, year, type, quantity, drink_from, drink_until, location}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `wine-tracker/tests/test_api_ha.py`:
+
+```python
+# ── compute_drink_window / /api/drink-window ────────────────────────────────────
+def test_drink_window_buckets_both_bounds(db):
+    _insert(db, name="Ready", type="Rotwein", quantity=1, drink_from=2022, drink_until=2028)
+    _insert(db, name="Young", quantity=1, drink_from=2030, drink_until=2035)
+    _insert(db, name="Past", quantity=1, drink_from=2010, drink_until=2020)
+    _insert(db, name="Unknown", quantity=1)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["counts"] == {"ready": 1, "too_young": 1, "past_peak": 1, "unknown": 1}
+    assert dw["ready_now"] == 1
+    assert dw["ready"][0]["name"] == "Ready"
+    assert dw["ready"][0]["type"] == "Red Wine"        # English label
+    assert dw["too_young"][0]["name"] == "Young"
+    assert dw["past_peak"][0]["name"] == "Past"
+    assert dw["unknown"][0]["name"] == "Unknown"
+
+
+def test_drink_window_one_sided_bounds(db):
+    _insert(db, name="OnlyFromReady", quantity=1, drink_from=2025, drink_until=None)
+    _insert(db, name="OnlyFromYoung", quantity=1, drink_from=2030, drink_until=None)
+    _insert(db, name="OnlyUntilReady", quantity=1, drink_from=None, drink_until=2026)
+    _insert(db, name="OnlyUntilPast", quantity=1, drink_from=None, drink_until=2020)
+    dw = api_queries.compute_drink_window(db, 2026)
+    names = lambda bucket: {e["name"] for e in dw[bucket]}
+    assert names("ready") == {"OnlyFromReady", "OnlyUntilReady"}
+    assert names("too_young") == {"OnlyFromYoung"}
+    assert names("past_peak") == {"OnlyUntilPast"}
+
+
+def test_drink_window_entering_and_leaving(db):
+    _insert(db, name="Entering", quantity=1, drink_from=2026, drink_until=2030)
+    _insert(db, name="Leaving", quantity=1, drink_from=2020, drink_until=2026)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["entering_this_year"] == 1
+    assert dw["leaving_this_year"] == 1
+
+
+def test_drink_window_excludes_out_of_stock(db):
+    _insert(db, name="Empty", quantity=0, drink_from=2022, drink_until=2028)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["counts"] == {"ready": 0, "too_young": 0, "past_peak": 0, "unknown": 0}
+
+
+def test_drink_window_route(client, db):
+    _insert(db, name="Ready", quantity=1, drink_from=2022, drink_until=2028)
+    resp = client.get("/api/drink-window")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert "current_year" in data
+    assert set(data["counts"]) == {"ready", "too_young", "past_peak", "unknown"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k drink_window -v`
+Expected: FAIL — `AttributeError: module 'api_queries' has no attribute 'compute_drink_window'`.
+
+- [ ] **Step 3a: Add `compute_drink_window` to `api_queries.py`**
+
+Append to `wine-tracker/app/api_queries.py`:
+
+```python
+_FAR_YEAR = 9999  # sort sentinel so None drink years sort last without comparing None
+
+
+def _dw_entry(row):
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "year": row["year"],
+        "type": type_en(row["type"]),
+        "quantity": row["quantity"],
+        "drink_from": row["drink_from"],
+        "drink_until": row["drink_until"],
+        "location": row["location"],
+    }
+
+
+def compute_drink_window(db, current_year):
+    """Bucket in-stock wines (quantity > 0) by drinking-window state for current_year."""
+    rows = db.execute(
+        "SELECT id, name, year, type, quantity, drink_from, drink_until, location "
+        "FROM wines WHERE quantity > 0"
+    ).fetchall()
+
+    ready, too_young, past_peak, unknown = [], [], [], []
+    entering = leaving = 0
+    for r in rows:
+        frm, until = r["drink_from"], r["drink_until"]
+        if frm is None and until is None:
+            unknown.append(r)
+            continue
+        if frm == current_year:
+            entering += 1
+        if until == current_year:
+            leaving += 1
+        if frm is not None and current_year < frm:
+            too_young.append(r)
+        elif until is not None and current_year > until:
+            past_peak.append(r)
+        else:
+            ready.append(r)
+
+    ready.sort(key=lambda r: r["drink_until"] if r["drink_until"] is not None else _FAR_YEAR)
+    too_young.sort(key=lambda r: r["drink_from"] if r["drink_from"] is not None else _FAR_YEAR)
+    past_peak.sort(key=lambda r: r["drink_until"] if r["drink_until"] is not None else _FAR_YEAR)
+    unknown.sort(key=lambda r: (r["name"] or "").lower())
+
+    return {
+        "current_year": current_year,
+        "ready_now": len(ready),
+        "entering_this_year": entering,
+        "leaving_this_year": leaving,
+        "counts": {
+            "ready": len(ready),
+            "too_young": len(too_young),
+            "past_peak": len(past_peak),
+            "unknown": len(unknown),
+        },
+        "ready": [_dw_entry(r) for r in ready],
+        "too_young": [_dw_entry(r) for r in too_young],
+        "past_peak": [_dw_entry(r) for r in past_peak],
+        "unknown": [_dw_entry(r) for r in unknown],
+    }
+```
+
+- [ ] **Step 3b: Wire the route into `app.py`**
+
+Add immediately after the `api_stats` route (before `# ── Main ──`):
+
+```python
+@app.route("/api/drink-window")
+def api_drink_window():
+    db = get_db()
+    return jsonify(ok=True, **api_queries.compute_drink_window(db, datetime.now().year))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k drink_window -v`
+Expected: PASS (5 drink-window tests).
+
+- [ ] **Step 5: Run the full test file**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -v`
+Expected: PASS (19 tests total so far).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wine-tracker/app/api_queries.py wine-tracker/app/app.py wine-tracker/tests/test_api_ha.py
+git commit -m "Add GET /api/drink-window endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `query_wines` + `GET /api/wines` (filterable list)
+
+**Files:**
+- Modify: `wine-tracker/app/api_queries.py` (add `_int_or_none`, `_SORT_COLUMNS`, `query_wines`)
+- Modify: `wine-tracker/app/app.py` (add route before `# ── Main ──`)
+- Modify: `wine-tracker/tests/test_api_ha.py` (add list tests)
+
+**Interfaces:**
+- Consumes: `serialize_wine`, `resolve_type_filter` (Task 1).
+- Produces: `query_wines(db, params) -> dict` with keys `count` (total matching, pre-pagination), `returned` (page size), `wines` (list of light records). `params` is any mapping with `.get()` (Flask `request.args` or a plain dict).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `wine-tracker/tests/test_api_ha.py`:
+
+```python
+# ── query_wines / /api/wines ────────────────────────────────────────────────────
+def test_wines_list_light_projection(client, db):
+    _insert(db, name="A", type="Rotwein", image="a.jpg", maturity_data='{"k":1}',
+            taste_profile='{"b":2}', food_pairings='["x"]')
+    resp = client.get("/api/wines")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert data["count"] == 1
+    assert data["returned"] == 1
+    w = data["wines"][0]
+    assert w["type"] == "Red Wine"
+    assert w["image_path"] == "/uploads/a.jpg"
+    assert "maturity_data" not in w
+    assert "taste_profile" not in w
+    assert "food_pairings" not in w
+
+
+def test_wines_filter_type_english(client, db):
+    _insert(db, name="Red", type="Rotwein")
+    _insert(db, name="White", type="Weisswein")
+    resp = client.get("/api/wines?type=Red Wine")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "Red"
+
+
+def test_wines_filter_region_substring(client, db):
+    _insert(db, name="A", region="Bordeaux, FR")
+    _insert(db, name="B", region="Tuscany, IT")
+    resp = client.get("/api/wines?region=Bordeaux")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "A"
+
+
+def test_wines_filter_grape_year_rating(client, db):
+    _insert(db, name="A", grape="Merlot", year=2018, rating=5)
+    _insert(db, name="B", grape="Syrah", year=2020, rating=2)
+    assert json.loads(client.get("/api/wines?grape=Merlot").data)["count"] == 1
+    assert json.loads(client.get("/api/wines?year=2020").data)["count"] == 1
+    assert json.loads(client.get("/api/wines?min_rating=3").data)["count"] == 1
+
+
+def test_wines_filter_in_stock(client, db):
+    _insert(db, name="Full", quantity=2)
+    _insert(db, name="Empty", quantity=0)
+    resp = client.get("/api/wines?in_stock=true")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "Full"
+
+
+def test_wines_sort_year_desc(client, db):
+    _insert(db, name="Old", year=2018)
+    _insert(db, name="New", year=2020)
+    resp = client.get("/api/wines?sort=year&order=desc")
+    data = json.loads(resp.data)
+    assert [w["year"] for w in data["wines"]] == [2020, 2018]
+
+
+def test_wines_invalid_sort_falls_back(client, db):
+    _insert(db, name="A")
+    resp = client.get("/api/wines?sort=banana&order=sideways")
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data["ok"] is True
+
+
+def test_wines_pagination(client, db):
+    for i in range(3):
+        _insert(db, name=f"W{i}")
+    resp = client.get("/api/wines?limit=2")
+    data = json.loads(resp.data)
+    assert data["count"] == 3
+    assert data["returned"] == 2
+    assert len(data["wines"]) == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k "wines_" -v`
+Expected: FAIL — the `/api/wines` route doesn't exist (404 → `KeyError`/assertion failures).
+
+- [ ] **Step 3a: Add `query_wines` to `api_queries.py`**
+
+Append to `wine-tracker/app/api_queries.py`:
+
+```python
+_SORT_COLUMNS = {
+    "name": "name", "year": "year", "rating": "rating",
+    "price": "price", "added": "added", "quantity": "quantity",
+}
+
+
+def _int_or_none(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def query_wines(db, params):
+    """Filter / sort / paginate the collection.
+
+    `params` is any mapping with .get() (Flask request.args or a plain dict).
+    Unknown or uninterpretable params are ignored (lenient — never raises).
+    Returns {count, returned, wines} where `wines` are light records.
+    """
+    where, args = [], []
+
+    type_val = params.get("type")
+    if type_val:
+        where.append("type = ?")
+        args.append(resolve_type_filter(type_val))
+
+    region = params.get("region")
+    if region:
+        where.append("region LIKE ?")
+        args.append(f"%{region}%")
+
+    grape = params.get("grape")
+    if grape:
+        where.append("grape LIKE ?")
+        args.append(f"%{grape}%")
+
+    year = _int_or_none(params.get("year"))
+    if year is not None:
+        where.append("year = ?")
+        args.append(year)
+
+    if str(params.get("in_stock", "")).lower() in ("1", "true", "yes"):
+        where.append("quantity > 0")
+
+    min_rating = _int_or_none(params.get("min_rating"))
+    if min_rating is not None:
+        where.append("rating >= ?")
+        args.append(min_rating)
+
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    total = db.execute(f"SELECT COUNT(*) FROM wines{where_sql}", args).fetchone()[0]
+
+    sort_col = _SORT_COLUMNS.get((params.get("sort") or "").lower(), "name")
+    order = "DESC" if (params.get("order") or "").lower() == "desc" else "ASC"
+    order_sql = f" ORDER BY {sort_col} {order}, name COLLATE NOCASE ASC"
+
+    limit = _int_or_none(params.get("limit"))
+    offset = _int_or_none(params.get("offset")) or 0
+    limit_sql, page_args = "", list(args)
+    if limit is not None and 1 <= limit <= 500:
+        limit_sql = " LIMIT ? OFFSET ?"
+        page_args.extend([limit, max(offset, 0)])
+
+    rows = db.execute(
+        f"SELECT * FROM wines{where_sql}{order_sql}{limit_sql}", page_args
+    ).fetchall()
+    wines = [serialize_wine(r, full=False) for r in rows]
+    return {"count": total, "returned": len(wines), "wines": wines}
+```
+
+Note: `sort_col` and `order` are drawn from fixed whitelists, never interpolated from raw user input, so the f-string SQL is injection-safe. All value filters are parameterized.
+
+- [ ] **Step 3b: Wire the route into `app.py`**
+
+Add immediately after the `api_drink_window` route (before `# ── Main ──`):
+
+```python
+@app.route("/api/wines")
+def api_wines_list():
+    db = get_db()
+    return jsonify(ok=True, **api_queries.query_wines(db, request.args))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k "wines_" -v`
+Expected: PASS (8 list tests).
+
+- [ ] **Step 5: Run the full test file**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -v`
+Expected: PASS (27 tests total so far).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wine-tracker/app/api_queries.py wine-tracker/app/app.py wine-tracker/tests/test_api_ha.py
+git commit -m "Add GET /api/wines filterable list endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `GET /api/wines/<id>` (detail) + auth regression
+
+**Files:**
+- Modify: `wine-tracker/app/app.py` (add route before `# ── Main ──`)
+- Modify: `wine-tracker/tests/test_api_ha.py` (add detail + auth tests)
+
+**Interfaces:**
+- Consumes: `serialize_wine` (Task 1). No new `api_queries` function.
+- Produces: route `GET /api/wines/<int:wine_id>` → `{"ok": true, "wine": <full record>}` or `404 {"ok": false, "error": "not_found"}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `wine-tracker/tests/test_api_ha.py`:
+
+```python
+# ── /api/wines/<id> detail ──────────────────────────────────────────────────────
+def test_wine_detail_full_record(client, db):
+    wid = _insert(db, name="A", type="Rotwein", image="a.jpg",
+                  maturity_data='{"k": 1}', food_pairings='["cheese"]')
+    resp = client.get(f"/api/wines/{wid}")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    w = data["wine"]
+    assert w["type"] == "Red Wine"
+    assert w["image_path"] == "/uploads/a.jpg"
+    assert w["maturity_data"] == {"k": 1}        # parsed, present in detail
+    assert w["food_pairings"] == ["cheese"]
+
+
+def test_wine_detail_not_found(client):
+    resp = client.get("/api/wines/999999")
+    data = json.loads(resp.data)
+    assert resp.status_code == 404
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# ── auth gate (mirrors test_api.py auth pattern) ────────────────────────────────
+def test_api_requires_auth_when_enabled():
+    import app as wine_app
+    wine_app.init_db()
+    wine_app.AUTH_ENABLED = True
+    try:
+        c = wine_app.app.test_client()
+        assert c.get("/api/stats").status_code == 401
+        assert c.get("/api/wines").status_code == 401
+        assert c.get("/api/drink-window").status_code == 401
+        assert c.get("/api/wines/1").status_code == 401
+    finally:
+        wine_app.AUTH_ENABLED = False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k "detail or requires_auth" -v`
+Expected: FAIL — `/api/wines/<id>` route returns 404 for the existing wine too (no route yet) / the detail assertions fail.
+
+- [ ] **Step 3: Add the detail route to `app.py`**
+
+Add immediately after the `api_wines_list` route (before `# ── Main ──`):
+
+```python
+@app.route("/api/wines/<int:wine_id>")
+def api_wines_detail(wine_id):
+    db = get_db()
+    row = db.execute("SELECT * FROM wines WHERE id = ?", (wine_id,)).fetchone()
+    if not row:
+        return jsonify(ok=False, error="not_found"), 404
+    return jsonify(ok=True, wine=api_queries.serialize_wine(row, full=True))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd wine-tracker && python -m pytest tests/test_api_ha.py -k "detail or requires_auth" -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full suite (regression check)**
+
+Run: `cd wine-tracker && python -m pytest -q`
+Expected: PASS — all pre-existing tests plus the new `test_api_ha.py` (30 new tests). No failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wine-tracker/app/app.py wine-tracker/tests/test_api_ha.py
+git commit -m "Add GET /api/wines/<id> detail endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Docs + version bump
+
+No tests — the deliverable is documentation and a synchronized version bump.
+
+**Files:**
+- Modify: `README.md` (the "Home Assistant Sensor (Optional)" section, ~line 278)
+- Modify: `CHANGELOG.md` (add `## 1.12.0` at top, under `# Changelog`)
+- Modify: `wine-tracker/CHANGELOG.md` (identical content — keep the two in sync)
+- Modify: `wine-tracker/config.yaml:3` (`version: "1.11.0"` → `"1.12.0"`)
+- Modify: `wine-tracker/app/app.py:146` (`APP_VERSION = "1.11.0"` → `"1.12.0"`)
+
+> **Note:** `origin/main` already shipped `1.11.0` (duplicate detection, `/api/summary` English types, etc.) — that version is taken. These new endpoints are a minor feature, so they bump to **`1.12.0`**, and the new CHANGELOG block goes **above** the existing `## 1.11.0` section.
+
+- [ ] **Step 1: Expand the README "Home Assistant Sensor" section**
+
+In `README.md`, replace the existing single sensor example block (the fenced yaml under "## Home Assistant Sensor (Optional)" plus the line after it) with:
+
+````markdown
+The add-on exposes read-only JSON endpoints for dashboards and automations. All return
+`{"ok": true, ...}` and use **English** wine-type labels regardless of the UI language.
+
+| Endpoint | Returns |
+|----------|---------|
+| `/api/summary` | total bottle count + by-type breakdown (legacy, unchanged) |
+| `/api/stats` | totals, liters, value, average age/rating, breakdowns by type/region/grape/decade |
+| `/api/drink-window` | wines bucketed `ready` / `too_young` / `past_peak` / `unknown`, plus year-boundary counts |
+| `/api/wines` | the collection as JSON, filterable & sortable (`?type=`, `?region=`, `?in_stock=true`, `?sort=year&order=desc`, `?limit=`) |
+| `/api/wines/<id>` | one wine, full detail incl. maturity / taste / pairings |
+
+### Stock & value sensor
+
+```yaml
+# configuration.yaml
+sensor:
+  - platform: rest
+    name: "Wine Cellar"
+    resource: "http://localhost:5050/api/stats"
+    value_template: "{{ value_json.total_bottles }}"
+    unit_of_measurement: "bottles"
+    json_attributes:
+      - total_liters
+      - total_value
+      - avg_age
+      - by_type
+    scan_interval: 3600
+```
+
+### Drink-window sensor + notification
+
+```yaml
+# configuration.yaml
+sensor:
+  - platform: rest
+    name: "Wines Ready to Drink"
+    resource: "http://localhost:5050/api/drink-window"
+    value_template: "{{ value_json.ready_now }}"
+    unit_of_measurement: "wines"
+    json_attributes:
+      - entering_this_year
+      - leaving_this_year
+    scan_interval: 86400
+
+automation:
+  - alias: "Wine entering its drink window"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.wines_ready_to_drink
+        attribute: entering_this_year
+        above: 0
+    action:
+      - service: notify.notify
+        data:
+          message: >
+            {{ state_attr('sensor.wines_ready_to_drink', 'entering_this_year') }}
+            wine(s) just entered their optimal drinking window.
+```
+
+> **Note (standalone Docker):** when `AUTH_ENABLED=true`, these endpoints require a logged-in
+> session, so an unauthenticated REST sensor receives `401`. In the Home Assistant add-on
+> (the default), access is gated by HA and the sensors work as shown.
+````
+
+- [ ] **Step 2: Add the CHANGELOG entry (both files, identical)**
+
+In **both** `CHANGELOG.md` and `wine-tracker/CHANGELOG.md`, insert this block between `# Changelog` and the existing `## 1.11.0`:
+
+```markdown
+## 1.12.0
+
+- **Extended read-only REST API** - new JSON endpoints for Home Assistant dashboards & automations: `/api/stats` (totals, liters, value, average age/rating, breakdowns by type/region/grape/decade), `/api/drink-window` (wines bucketed ready / too young / past peak, with year-boundary counts for notifications), `/api/wines` (the filterable, sortable collection) and `/api/wines/<id>` (single-wine detail). All use English wine-type labels regardless of UI language. The existing `/api/summary` is unchanged. Resolves the "Extended REST API" roadmap item.
+- **Tests** - added 30 tests for the new API query helpers and routes.
+```
+
+- [ ] **Step 3: Bump the version (three references in sync)**
+
+In `wine-tracker/config.yaml` line 3:
+
+```yaml
+version: "1.12.0"
+```
+
+In `wine-tracker/app/app.py` line 146:
+
+```python
+APP_VERSION = "1.12.0"
+```
+
+- [ ] **Step 4: Verify versions are consistent**
+
+Run: `cd /Users/ofer/conductor/workspaces/ha-wine-tracker/cairo && grep -rn "1.12.0" wine-tracker/config.yaml wine-tracker/app/app.py CHANGELOG.md wine-tracker/CHANGELOG.md`
+Expected: one match in each of the four files (the `version:`/`APP_VERSION` lines and the new `## 1.12.0` CHANGELOG headings). The pre-existing `## 1.11.0` sections remain below.
+
+- [ ] **Step 5: Run the full suite once more**
+
+Run: `cd wine-tracker && python -m pytest -q`
+Expected: PASS (full suite green — the version-string change must not break the export test that reads `APP_VERSION`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md CHANGELOG.md wine-tracker/CHANGELOG.md wine-tracker/config.yaml wine-tracker/app/app.py
+git commit -m "Document HA REST API and bump version to 1.12.0
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:**
+- `/api/stats` → Task 2 ✓ · `/api/drink-window` → Task 3 ✓ · `/api/wines` (light, filter/sort/paginate) → Task 4 ✓ · `/api/wines/<id>` (full) → Task 5 ✓
+- Pure module `api_queries.py` + thin routes → Tasks 1–5 ✓
+- English `type` everywhere → `type_en` / `serialize_wine` (Task 1), asserted in Tasks 2–5 ✓
+- Lenient params (no 400) → `query_wines` + `test_wines_invalid_sort_falls_back` (Task 4) ✓
+- Auth inherited, no new code → `test_api_requires_auth_when_enabled` (Task 5) ✓
+- Light list omits AI blobs / detail parses them → Tasks 1, 4, 5 ✓
+- Docs (README + CHANGELOG) → Task 6 ✓
+
+**Placeholder scan:** No TBD/TODO; every code and test step contains complete code; every run step has an exact command + expected outcome.
+
+**Type consistency:** `type_en`, `resolve_type_filter`, `serialize_wine`, `compute_stats`, `compute_drink_window`, `_dw_entry`, `query_wines`, `_int_or_none`, `_SORT_COLUMNS` are named identically wherever referenced across tasks. Route function names (`api_stats`, `api_drink_window`, `api_wines_list`, `api_wines_detail`) are unique and don't collide with existing routes (`api_summary`, `api_get_wine` at `/api/wine/<id>`).
+
+**Edge cases covered by tests:** empty DB; NULL/empty type-region-grape excluded from breakdowns; one-sided drink windows; out-of-stock exclusion; year-boundary entering/leaving; invalid sort fallback; pagination count-vs-returned; 404 on missing wine; auth 401 gate.

--- a/docs/superpowers/specs/2026-06-21-add-duplicate-detection-design.md
+++ b/docs/superpowers/specs/2026-06-21-add-duplicate-detection-design.md
@@ -1,0 +1,142 @@
+# Duplicate detection on the add flow — design
+
+**Date:** 2026-06-21
+**Status:** Approved (pending implementation)
+
+## Problem
+
+Adding a wine via the AI label feature (or Vivino search, or manually) always inserts
+a new row through `POST /add`. There is no check against the existing cellar, so re-adding
+a wine you already own produces a second card instead of bumping its quantity. Deduplication
+currently exists **only** in the ZIP/CSV restore path (`match_wines()` in `export_import.py`),
+never in the normal add flow.
+
+This adds opt-in duplicate detection to `POST /add` so the user is asked what to do when an
+incoming wine matches one already in the cellar.
+
+## Scope
+
+- Lives entirely in `POST /add`, so it covers **all** add paths (AI, Vivino, manual) at once.
+- `/edit` and `/duplicate` are untouched. (`/duplicate` is intentional cloning.)
+- No schema change. No new columns.
+
+## Matching rule
+
+A wine is "the same" when **all three** match:
+
+- `name` — case-insensitive, whitespace-trimmed on both sides
+- `year` (vintage)
+- `bottle_format`
+
+A different vintage **or** a different bottle size is a distinct cellar entry and does **not** match.
+
+Match query (most-recent first, first row wins):
+
+```sql
+SELECT id, name, year, bottle_format, quantity, location
+FROM wines
+WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+  AND year IS ?
+  AND bottle_format = ?
+ORDER BY id DESC
+LIMIT 1
+```
+
+Notes:
+- Matches **regardless of quantity**, so an empty-bottle placeholder (quantity 0) of the same
+  wine gets restocked rather than duplicated.
+- `year IS ?` handles the NULL-vintage case correctly (`NULL IS NULL` is true in SQLite).
+- `bottle_format` defaults to `0.75` on insert when the form value is empty; the form always
+  submits a value, so the comparison is stable.
+- If multiple separate entries share the same name/year/format (e.g. different storage
+  locations), the most recent one is offered. The dialog shows its `location` so the user can
+  choose "Add as separate entry" if it is the wrong one. Resolving multi-match precisely is out
+  of scope for v1.
+
+## Mechanism — two-phase `/add`
+
+`/add` gains one optional form field, `dup_action`:
+
+| `dup_action` | Behavior |
+|---|---|
+| _(empty, default)_ | Run the match query. **If a match exists, do not insert** — return `{"ok": false, "duplicate": {...}}`. If no match, insert as today. |
+| `"separate"` | Skip the check entirely; insert a new row as today. |
+| `"merge"` (with `dup_target_id`) | Increment the target wine's `quantity` by the form quantity, log a `restocked` timeline entry, return `{"ok": true, "wine": ..., "stats": ...}`. |
+
+The `duplicate` payload returned in phase one:
+
+```json
+{
+  "ok": false,
+  "duplicate": {
+    "id": 12,
+    "name": "Château Test",
+    "year": 2018,
+    "bottle_format": 0.75,
+    "quantity": 3,
+    "location": "Keller A"
+  }
+}
+```
+
+### Merge semantics (decision: quantity only)
+
+On `merge`, only the quantity changes. All other form fields (notes, rating, maturity data,
+price, location, image, etc.) are **ignored** — the existing card stays the source of truth.
+Enriching an existing wine is already covered by the separate "Reload missing data" feature.
+
+Increment amount = the `quantity` field from the form (so adding 2 bottles bumps 3 → 5).
+The timeline entry mirrors the existing edit-route pattern (`app.py:905-909`):
+
+```python
+db.execute(
+    "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+    (target_id, "restocked", added_qty, datetime.now().isoformat()),
+)
+```
+
+### Readonly / auth
+
+`merge` and `separate` are write operations and must pass the same `check_readonly()` /
+`check_auth()` gates the rest of `/add` already enforces. No special-casing needed since they
+flow through the same route.
+
+## Frontend — add-form submit (`index.html`)
+
+The existing add-form submit posts a `FormData` to `/add` via fetch and updates the UI on
+`ok:true`. Change the response handling:
+
+1. On `{ok:false, duplicate}` → show a confirm dialog (reusing the app's existing modal/dialog
+   styling, theme-aware per `STYLE_GUIDE.md`) showing:
+   `You already have {quantity}× {name} {year} ({bottle_format}l) in {location}.`
+   with three buttons:
+   - **Add to existing (now N)** → re-POST the same FormData with `dup_action=merge` and
+     `dup_target_id=<id>`.
+   - **Add as separate entry** → re-POST the same FormData with `dup_action=separate`.
+   - **Cancel** → close dialog, leave the add form open and untouched.
+2. On `{ok:false}` with any other error → existing error handling, unchanged.
+3. On `{ok:true}` → existing success handling, unchanged.
+
+All three button labels and the dialog body text go through `translations.py` for all 7
+languages (new keys, e.g. `dup_detect_title`, `dup_detect_body`, `dup_detect_merge`,
+`dup_detect_separate`, `dup_detect_cancel`).
+
+## Tests (`tests/test_routes.py`)
+
+- No existing wine → `/add` inserts normally, `ok:true` (regression).
+- Matching wine, no `dup_action` → `ok:false` with correct `duplicate` payload; **no new row** inserted.
+- `dup_action=merge` + `dup_target_id` → target quantity increased by form quantity; a
+  `restocked` timeline row is written; no new wine row.
+- `dup_action=separate` → a second row is inserted despite the match.
+- Case-insensitive + whitespace match: `"  château test "` matches `"Château Test"`.
+- Different `year` → no match (inserts).
+- Different `bottle_format` → no match (inserts).
+- NULL-vintage match: two wines with `year=NULL`, same name/format → match.
+- Empty-bottle restock: existing match with `quantity=0`, merge → quantity becomes the form qty.
+
+## Out of scope
+
+- Field backfill on merge (option B from brainstorming) — explicitly rejected for v1.
+- Multi-match disambiguation UI.
+- Dedup on `/edit`.
+- Changing the import (`match_wines`) behavior.

--- a/docs/superpowers/specs/2026-06-21-ha-rest-api-design.md
+++ b/docs/superpowers/specs/2026-06-21-ha-rest-api-design.md
@@ -1,0 +1,229 @@
+# Extended HA read-only REST API — design
+
+**Date:** 2026-06-21
+**Status:** Approved (pending implementation)
+
+## Problem
+
+The only machine-readable endpoint built for Home Assistant is `GET /api/summary`
+(`app.py:3134`), which returns total bottle count + a by-type breakdown. The ROADMAP calls for
+an *"Extended REST API — more endpoints (single wine, stats, collection export) for dashboards &
+automations."* Everything richer that the UI shows (total value, liters, average age, drink
+windows, the full collection) is computed server-side only for HTML rendering (e.g. the `/stats`
+page at `app.py:1227`) and is not reachable as JSON.
+
+This adds a small set of **read-only** JSON endpoints aimed at Home Assistant: rich stats,
+drink-window buckets, and a filterable collection list + single-wine detail. They let users build
+many sensors from one poll and drive drink-window notifications.
+
+## Decisions (from brainstorming)
+
+1. **Consumer:** Home Assistant sensors/automations — read-only. No write endpoints.
+2. **Scope:** four endpoints — `/api/stats`, `/api/drink-window`, `/api/wines`, `/api/wines/<id>`.
+3. **Auth:** no new mechanism. The endpoints inherit the existing `check_auth` rule (`app.py:345`),
+   exactly like `/api/summary`: open when `AUTH_ENABLED=false` (the standard HA add-on), session-gated
+   when `AUTH_ENABLED=true` (standalone Docker). No API token.
+4. **Labels:** wine `type` is returned as the **English** canonical label everywhere (following
+   `/api/summary`, `app.py:3142`), so HA automations are stable regardless of UI language.
+5. **Structure:** a new pure-Python module `wine-tracker/app/api_queries.py` holds all
+   query/aggregation logic; `app.py` gains four thin route handlers that call it and `jsonify`.
+6. **List vs detail:** `/api/wines` returns a **light** projection (omits the large AI JSON blobs);
+   `/api/wines/<id>` returns the **full** record including parsed AI JSON.
+
+## Conventions followed
+
+- Response envelope: success `{"ok": true, ...}`, error `{"ok": false, "error": "..."}` + HTTP code
+  (the dominant pattern, e.g. `/api/wine/<id>` at `app.py:3125`).
+- Type → English via `TRANSLATIONS["en"].get(f"wine_type_{raw}", raw)`. Canonical stored keys are
+  `WINE_TYPES = ["Rotwein","Weisswein","Rosé","Schaumwein","Dessertwein","Likörwein","Anderes"]`
+  → `Red Wine / White Wine / Rosé / Sparkling Wine / Dessert Wine / Fortified Wine / Other`.
+- **Lenient query params:** bad/unknown params never 400 — they fall back to defaults. A sensor that
+  sends a typo'd filter still gets data, not an error.
+- Flat `/api/` prefix (consistent with existing endpoints). No `/v1/` versioning.
+
+## Module: `wine-tracker/app/api_queries.py` (pure, no Flask)
+
+Imports only `from translations import TRANSLATIONS`. All functions take an open sqlite3
+connection (`sqlite3.Row` factory) and plain values, so they are unit-testable without HTTP.
+
+```python
+def type_en(raw):                       # "Rotwein" -> "Red Wine"; unknown/empty -> raw or None
+def serialize_wine(row, full=False):    # dict(row) + English type + image_path; full parses AI JSON, else drops it
+def compute_stats(db, current_year):    # -> dict of aggregates (no envelope, no currency)
+def compute_drink_window(db, current_year):  # -> dict of buckets + counts + scalars
+def query_wines(db, params):            # params: any mapping with .get() (request.args or dict) -> {count, returned, wines}
+```
+
+`serialize_wine` rules:
+- `type` is replaced with its English label (raw stored value is **not** also returned — decision 4).
+- `image_path` = `"/uploads/<image>"` when `image` is set, else `null` (`image` filename kept too).
+- `full=True`: parse `maturity_data` / `taste_profile` / `food_pairings` from JSON text to objects
+  (same logic as `wine_json`, `app.py:594`).
+- `full=False`: those three keys are **omitted** entirely.
+
+## Endpoint 1 — `GET /api/stats`
+
+Route: `data = compute_stats(db, datetime.now().year)`, then add `currency` from
+`HA_OPTIONS`, return `jsonify(ok=True, **data)`.
+
+Aggregates (SQL mirrors `app.py:1233-1305`; floats rounded — money/liters to 2 dp, age/rating to 1 dp):
+
+```json
+{
+  "ok": true,
+  "currency": "CHF",
+  "total_bottles": 42,          // SUM(quantity)
+  "distinct_wines": 18,         // COUNT(*) wine entries
+  "out_of_stock": 2,            // COUNT(*) WHERE quantity = 0  (empty placeholders)
+  "total_liters": 31.5,         // SUM(quantity * COALESCE(bottle_format, 0.75))
+  "total_value": 1234.5,        // SUM(quantity * price) WHERE price > 0
+  "avg_price": 29.4,            // AVG(price) WHERE price > 0
+  "avg_age": 6.2,               // AVG(current_year - year) WHERE year > 0
+  "avg_rating": 3.8,            // AVG(rating) WHERE rating > 0
+  "by_type":   [{"type": "Red Wine", "bottles": 20, "wines": 8}, ...],   // GROUP BY type, English, qty desc
+  "by_region": [{"region": "Bordeaux", "bottles": 12}, ...],             // GROUP BY region, qty desc
+  "by_grape":  [{"grape": "Merlot", "bottles": 9}, ...],                 // GROUP BY grape, qty desc
+  "by_decade": [{"decade": 2010, "bottles": 15}, ...]                    // (year/10)*10, asc
+}
+```
+
+- `by_type` / `by_region` / `by_grape` exclude rows whose field is NULL/empty (matches the `/stats` donut).
+- Empty cellar → scalars `0` / `0.0`, breakdowns `[]`, `ok: true`.
+- Flat top-level scalars so HA `json_attributes` can read them directly.
+
+## Endpoint 2 — `GET /api/drink-window`
+
+Route: `jsonify(ok=True, **compute_drink_window(db, datetime.now().year))`.
+Considers only **in-stock** wines (`quantity > 0`). `drink_from` / `drink_until` are INTEGER years.
+
+Bucketing for current year `Y`:
+
+| Window state | Bucket |
+|---|---|
+| both set, `from ≤ Y ≤ until` | `ready` |
+| both set, `Y < from` | `too_young` |
+| both set, `Y > until` | `past_peak` |
+| only `from` set: `Y ≥ from` → `ready`, else `too_young` | (no upper bound) |
+| only `until` set: `Y ≤ until` → `ready`, else `past_peak` | (no lower bound) |
+| neither set | `unknown` |
+
+Sort within buckets: `ready` by `drink_until` asc (soonest to expire first), `too_young` by
+`drink_from` asc, `past_peak` by `drink_until` asc, `unknown` by name.
+
+```json
+{
+  "ok": true,
+  "current_year": 2026,
+  "ready_now": 12,              // == len(ready), convenience scalar for value_template
+  "entering_this_year": 1,      // count of in-stock wines with drink_from == 2026
+  "leaving_this_year": 2,       // count of in-stock wines with drink_until == 2026
+  "counts": {"ready": 12, "too_young": 5, "past_peak": 2, "unknown": 3},
+  "ready":     [{"id":1,"name":"…","year":2018,"type":"Red Wine","quantity":2,"drink_from":2022,"drink_until":2028,"location":"Keller A"}, ...],
+  "too_young": [ ... ],
+  "past_peak": [ ... ],
+  "unknown":   [ ... ]
+}
+```
+
+Each entry: `{id, name, year, type (English), quantity, drink_from, drink_until, location}`.
+
+## Endpoint 3 — `GET /api/wines`
+
+Route: `jsonify(ok=True, **query_wines(db, request.args))`.
+
+Filters (all optional, ANDed, lenient — ignored if blank/uninterpretable):
+
+| Param | Effect |
+|---|---|
+| `type` | English label (case-insensitive) resolved back to the stored key; falls back to raw match. `type = ?` |
+| `region` | substring, case-insensitive: `region LIKE %v%` |
+| `grape` | substring, case-insensitive: `grape LIKE %v%` |
+| `year` | exact `year = ?` (int; ignored if non-numeric) |
+| `in_stock` | `true`/`1` → `quantity > 0` |
+| `min_rating` | `rating >= ?` (int; ignored if non-numeric) |
+
+Sort: `sort` ∈ {`name`,`year`,`rating`,`price`,`added`,`quantity`} (default `name`, invalid → `name`);
+`order` ∈ {`asc`,`desc`} (default `asc`). Secondary sort by `name` for stable ordering.
+
+Pagination: `limit` (int 1–500; otherwise no limit), `offset` (int ≥ 0; default 0). `count` is the
+total matching the filters **before** limit/offset; `returned` is the page size.
+
+```
+GET /api/wines?type=Red%20Wine&in_stock=true&sort=year&order=desc&limit=50
+→ { "ok": true, "count": 18, "returned": 18, "wines": [ <light record>, ... ] }
+```
+
+Light record = **every `wines` column except** `maturity_data` / `taste_profile` / `food_pairings`,
+with `type` in English and `image_path` added — i.e. `serialize_wine(row, full=False)`. Concretely:
+`id, name, year, type (English), region, quantity, rating, notes, image, image_path, added,
+purchased_at, price, drink_from, drink_until, location, grape, vivino_id, bottle_format`. The three
+AI JSON blobs are returned **only** by `/api/wines/<id>`.
+
+## Endpoint 4 — `GET /api/wines/<int:wine_id>`
+
+```python
+row = db.execute("SELECT * FROM wines WHERE id = ?", (wine_id,)).fetchone()
+if not row:
+    return jsonify(ok=False, error="not_found"), 404
+return jsonify(ok=True, wine=api_queries.serialize_wine(row, full=True))
+```
+
+Full record = every column, `type` in English, `image_path` added, and `maturity_data` /
+`taste_profile` / `food_pairings` parsed from JSON text into objects. This is a **new** endpoint;
+the existing `/api/wine/<id>` (singular, raw type) stays untouched for the UI's JS.
+
+## Auth / readonly
+
+No code changes. `check_auth` (`app.py:345`) already gates every `/api/*` path uniformly. All four
+endpoints are GET, so `check_readonly` (`app.py:358`) never blocks them. Behavior is identical to
+`/api/summary` today (decision 3).
+
+## Tests — `wine-tracker/tests/test_api_ha.py`
+
+Reuse existing fixtures (`client`, `db`, `sample_wine`, `_patch_env`). Two layers: direct calls to
+`api_queries` pure functions for boundary logic, plus Flask-client calls for the routes/envelope.
+
+**stats**
+- Empty DB → all scalars 0, breakdowns `[]`, `ok:true`, `currency` present.
+- Populated → correct `total_bottles`, `total_liters`, `total_value`, `avg_age`, `avg_rating`.
+- `by_type` uses English (`"Red Wine"`); `by_region` / `by_grape` / `by_decade` correct & ordered.
+- NULL/empty type, region, grape excluded from breakdowns.
+
+**drink-window** (drive `current_year` via the pure function for determinism)
+- `from ≤ Y ≤ until` → `ready`; `Y < from` → `too_young`; `Y > until` → `past_peak`; no window → `unknown`.
+- one-sided windows (only `from`, only `until`) bucket per the table.
+- `entering_this_year` / `leaving_this_year` counted on year boundaries.
+- `quantity = 0` excluded. `counts`, `ready_now`, English labels correct.
+
+**wines list**
+- Returns all; light projection (asserts `maturity_data`/`taste_profile`/`food_pairings` keys absent).
+- `type=Red Wine` matches `Rotwein` rows; `region`/`grape` substring; `year`; `in_stock=true` excludes qty 0; `min_rating`.
+- `sort=year&order=desc` ordering; invalid `sort` → falls back, still `ok:true` (no 400).
+- `limit`/`offset` → `count` vs `returned`. `image_path` present when image set. English `type` per record.
+
+**wines detail**
+- Existing id → `ok:true`, `type` English, `image_path`, `maturity_data` parsed to an object (not a string).
+- Missing id → `404`, `{"ok": false, "error": "not_found"}`.
+
+**auth regression**
+- With `AUTH_ENABLED=true` and no session, `GET /api/stats` → `401` (mirrors the existing
+  `/api/summary` auth-gate test pattern in `test_api.py`).
+
+## Docs
+
+- **README.md** "Home Assistant Sensor" section: add a `/api/stats` REST sensor (with
+  `json_attributes`), a `/api/drink-window` template sensor + a "wines entering their window"
+  notification automation, and a one-line mention of `/api/wines` for markdown-card lists.
+- **CHANGELOG.md**: add an entry for the new endpoints (next minor, 1.11.0).
+- **wine-tracker/DOCS.md**: mirror the sensor examples if it documents the API (optional).
+
+## Out of scope
+
+- Any write endpoint (create / update / delete / consume / restock) — read-only v1.
+- API-token / bearer auth — explicitly rejected (decision 3).
+- `/v1/` versioning prefix.
+- Refactoring the `/stats` HTML page to share `compute_stats` (touching working UI = risk, no payoff).
+- CORS headers (no separate-origin frontend in scope).
+- Changing `/api/summary`, `/api/wine/<id>`, or `/api/timeline`.
+- OpenAPI/Swagger discovery endpoint.
+- Returning the raw stored `type` alongside English (decision 4 chose English-only).

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: "Wine Tracker for Home Assistant"
-url: "https://github.com/xenofex7/ha-wine-tracker"
-maintainer: "xenofex7"
+url: "https://github.com/ofer8/ha-wine-tracker"
+maintainer: "ofer8"

--- a/wine-tracker/CHANGELOG.md
+++ b/wine-tracker/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.11.0
+
+- **Duplicate detection when adding a wine** - the add-wine flow now detects when a bottle closely matches one already in your cellar and lets you merge it into the existing entry or keep it as a separate row, with a confirmation dialog localised in all 7 languages.
+- **Fix duplicate entry when restocking** - restocking a wine could create a second row instead of increasing the existing bottle's quantity; the restock flow now updates the original entry.
+- **English wine types in `/api/summary`** - the summary feed consumed by Home Assistant REST sensors returned raw German type labels (Rotwein, Weisswein, ...); they are now mapped to English so sensors read consistently regardless of the configured UI language.
+- **Autocomplete on advanced-filter inputs** - the advanced filter's text fields now suggest existing values (region, grape, producer, ...) as you type.
+- **Advanced-filter badge fixes** - the filter button no longer shows an empty blue dot when no filters are active, and the badge count no longer includes stale empty rules.
+- **Mobile advanced-filter polish** - fixed several layout and interaction issues found on mobile while testing the v1.10.0 advanced filter.
+- **Renamed advanced-filter group labels** in all 7 languages for clarity.
+- **Replaced em/en-dashes with plain hyphens app-wide** for consistent rendering across fonts.
+- **Home Assistant dev-addon update script** - added `scripts/update-ha-dev.sh` for one-command updates from GitHub, using `ha apps` with first-install detection.
+- **Local Docker Compose setup** for development.
+- **Point add-on metadata at the ofer8 fork** so the add-on installs and links correctly from this fork.
+
 ## 1.10.0
 
 - **Advanced filter with multiple AND-conditions** - filter the cellar by any combination of fields (type, vintage, region, grape, rating, drink window, location, source, format, ...) in a single popover. Resolves #5.

--- a/wine-tracker/CHANGELOG.md
+++ b/wine-tracker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.12.0
+
+- **Extended read-only REST API** - new JSON endpoints for Home Assistant dashboards & automations: `/api/stats` (totals, liters, value, average age/rating, breakdowns by type/region/grape/decade), `/api/drink-window` (wines bucketed ready / too young / past peak, with year-boundary counts for notifications), `/api/wines` (the filterable, sortable collection) and `/api/wines/<id>` (single-wine detail). All use English wine-type labels regardless of UI language. The existing `/api/summary` is unchanged. Resolves the "Extended REST API" roadmap item.
+- **Tests** - added 32 tests for the new API query helpers and routes.
+
 ## 1.11.0
 
 - **Duplicate detection when adding a wine** - the add-wine flow now detects when a bottle closely matches one already in your cellar and lets you merge it into the existing entry or keep it as a separate row, with a confirmation dialog localised in all 7 languages.

--- a/wine-tracker/DOCS.md
+++ b/wine-tracker/DOCS.md
@@ -113,5 +113,5 @@ sensor:
 
 See the full documentation and changelog on [GitHub](https://github.com/xenofex7/ha-wine-tracker).
 
-[version-badge]: https://img.shields.io/badge/version-v1.10.0-blue.svg
+[version-badge]: https://img.shields.io/badge/version-v1.11.0-blue.svg
 [ai-badge]: https://img.shields.io/badge/AI%20powered-label%20recognition-blueviolet.svg

--- a/wine-tracker/README.md
+++ b/wine-tracker/README.md
@@ -35,7 +35,7 @@ Vivino to import wines with ratings and pricing.
 Data is stored locally under `/share/wine-tracker/` and preserved across
 updates and restarts.
 
-[version-badge]: https://img.shields.io/badge/version-v1.10.0-blue.svg
+[version-badge]: https://img.shields.io/badge/version-v1.11.0-blue.svg
 [stage-badge]: https://img.shields.io/badge/project%20stage-stable-brightgreen.svg
 [maintained-badge]: https://img.shields.io/badge/maintained-yes-brightgreen.svg
 [license-badge]: https://img.shields.io/badge/license-MIT-green.svg

--- a/wine-tracker/app/api_queries.py
+++ b/wine-tracker/app/api_queries.py
@@ -1,0 +1,274 @@
+"""Pure query/aggregation helpers for the read-only Home Assistant REST API.
+
+No Flask imports — every function takes an open sqlite3 connection (with a
+sqlite3.Row row_factory) and returns plain dict/list data, so they are
+unit-testable without an HTTP layer. The routes in app.py wrap these in jsonify().
+"""
+import json
+
+from translations import TRANSLATIONS
+
+_EN = TRANSLATIONS["en"]
+
+# Reverse lookup: lower-cased English label -> stored key, e.g. "red wine" -> "Rotwein".
+_EN_TO_KEY = {
+    label.lower(): key[len("wine_type_"):]
+    for key, label in _EN.items()
+    if key.startswith("wine_type_")
+}
+
+_AI_JSON_FIELDS = ("maturity_data", "taste_profile", "food_pairings")
+
+
+def type_en(raw):
+    """Translate a stored wine-type key ('Rotwein') to its English label ('Red Wine').
+
+    Unknown or falsy values are returned unchanged (None stays None, "" stays "").
+    """
+    if not raw:
+        return raw
+    return _EN.get(f"wine_type_{raw}", raw)
+
+
+def resolve_type_filter(value):
+    """Map an English type label back to its stored key for filtering.
+
+    'Red Wine' -> 'Rotwein' (case-insensitive). Unknown values pass through
+    unchanged, so raw stored keys still work as a filter.
+    """
+    if not value:
+        return value
+    return _EN_TO_KEY.get(value.strip().lower(), value)
+
+
+def serialize_wine(row, full=False):
+    """Convert a wines row (sqlite3.Row) to a JSON-ready dict.
+
+    - `type` is replaced with its English label.
+    - `image_path` is added ('/uploads/<image>' or None).
+    - full=True: the three AI JSON-text columns are parsed into objects.
+    - full=False: those three columns are omitted entirely.
+    """
+    d = dict(row)
+    d["type"] = type_en(d.get("type"))
+    image = d.get("image")
+    d["image_path"] = f"/uploads/{image}" if image else None
+    if full:
+        for key in _AI_JSON_FIELDS:
+            raw = d.get(key)
+            if raw:
+                try:
+                    d[key] = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    d[key] = None
+    else:
+        for key in _AI_JSON_FIELDS:
+            d.pop(key, None)
+    return d
+
+
+def compute_stats(db, current_year):
+    """Aggregate cellar statistics. Returns a flat dict (no envelope, no currency)."""
+    totals = db.execute(
+        "SELECT COALESCE(SUM(quantity), 0) AS bottles, COUNT(*) AS wines FROM wines"
+    ).fetchone()
+    out_of_stock = db.execute(
+        "SELECT COUNT(*) FROM wines WHERE quantity = 0"
+    ).fetchone()[0]
+    liters = db.execute(
+        "SELECT COALESCE(SUM(quantity * COALESCE(bottle_format, 0.75)), 0) FROM wines"
+    ).fetchone()[0]
+    value = db.execute(
+        "SELECT COALESCE(SUM(quantity * price), 0) AS total, AVG(price) AS avg "
+        "FROM wines WHERE price IS NOT NULL AND price > 0"
+    ).fetchone()
+    avg_age = db.execute(
+        "SELECT AVG(? - year) FROM wines WHERE year IS NOT NULL AND year > 0",
+        (current_year,),
+    ).fetchone()[0]
+    avg_rating = db.execute(
+        "SELECT AVG(rating) FROM wines WHERE rating > 0"
+    ).fetchone()[0]
+
+    by_type = [
+        {"type": type_en(r["type"]), "bottles": r["bottles"], "wines": r["wines"]}
+        for r in db.execute(
+            "SELECT type, COALESCE(SUM(quantity), 0) AS bottles, COUNT(*) AS wines "
+            "FROM wines WHERE type IS NOT NULL AND type != '' "
+            "GROUP BY type ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_region = [
+        {"region": r["region"], "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT region, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE region IS NOT NULL AND region != '' "
+            "GROUP BY region ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_grape = [
+        {"grape": r["grape"], "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT grape, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE grape IS NOT NULL AND grape != '' "
+            "GROUP BY grape ORDER BY bottles DESC"
+        ).fetchall()
+    ]
+    by_decade = [
+        {"decade": int(r["decade"]), "bottles": r["bottles"]}
+        for r in db.execute(
+            "SELECT (year / 10) * 10 AS decade, COALESCE(SUM(quantity), 0) AS bottles "
+            "FROM wines WHERE year IS NOT NULL AND year > 0 "
+            "GROUP BY decade ORDER BY decade ASC"
+        ).fetchall()
+    ]
+
+    return {
+        "total_bottles": totals["bottles"],
+        "distinct_wines": totals["wines"],
+        "out_of_stock": out_of_stock,
+        "total_liters": round(liters, 2),
+        "total_value": round(value["total"], 2),
+        "avg_price": round(value["avg"], 2) if value["avg"] is not None else 0.0,
+        "avg_age": round(avg_age, 1) if avg_age is not None else 0.0,
+        "avg_rating": round(avg_rating, 1) if avg_rating is not None else 0.0,
+        "by_type": by_type,
+        "by_region": by_region,
+        "by_grape": by_grape,
+        "by_decade": by_decade,
+    }
+
+
+_SORT_COLUMNS = {
+    "name": "name", "year": "year", "rating": "rating",
+    "price": "price", "added": "added", "quantity": "quantity",
+}
+
+
+def _int_or_none(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def query_wines(db, params):
+    """Filter / sort / paginate the collection.
+
+    `params` is any mapping with .get() (Flask request.args or a plain dict).
+    Unknown or uninterpretable params are ignored (lenient — never raises).
+    Returns {count, returned, wines} where `wines` are light records.
+    """
+    where, args = [], []
+
+    type_val = params.get("type")
+    if type_val:
+        where.append("type = ?")
+        args.append(resolve_type_filter(type_val))
+
+    region = params.get("region")
+    if region:
+        where.append("region LIKE ?")
+        args.append(f"%{region}%")
+
+    grape = params.get("grape")
+    if grape:
+        where.append("grape LIKE ?")
+        args.append(f"%{grape}%")
+
+    year = _int_or_none(params.get("year"))
+    if year is not None:
+        where.append("year = ?")
+        args.append(year)
+
+    if str(params.get("in_stock", "")).lower() in ("1", "true", "yes"):
+        where.append("quantity > 0")
+
+    min_rating = _int_or_none(params.get("min_rating"))
+    if min_rating is not None:
+        where.append("rating >= ?")
+        args.append(min_rating)
+
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    total = db.execute(f"SELECT COUNT(*) FROM wines{where_sql}", args).fetchone()[0]
+
+    sort_col = _SORT_COLUMNS.get((params.get("sort") or "").lower(), "name")
+    order = "DESC" if (params.get("order") or "").lower() == "desc" else "ASC"
+    order_sql = f" ORDER BY {sort_col} {order}, name COLLATE NOCASE ASC"
+
+    limit = _int_or_none(params.get("limit"))
+    offset = _int_or_none(params.get("offset")) or 0
+    limit_sql, page_args = "", list(args)
+    if limit is not None and 1 <= limit <= 500:
+        limit_sql = " LIMIT ? OFFSET ?"
+        page_args.extend([limit, max(offset, 0)])
+
+    rows = db.execute(
+        f"SELECT * FROM wines{where_sql}{order_sql}{limit_sql}", page_args
+    ).fetchall()
+    wines = [serialize_wine(r, full=False) for r in rows]
+    return {"count": total, "returned": len(wines), "wines": wines}
+
+
+_FAR_YEAR = 9999  # sort sentinel so None drink years sort last without comparing None
+
+
+def _dw_entry(row):
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "year": row["year"],
+        "type": type_en(row["type"]),
+        "quantity": row["quantity"],
+        "drink_from": row["drink_from"],
+        "drink_until": row["drink_until"],
+        "location": row["location"],
+    }
+
+
+def compute_drink_window(db, current_year):
+    """Bucket in-stock wines (quantity > 0) by drinking-window state for current_year."""
+    rows = db.execute(
+        "SELECT id, name, year, type, quantity, drink_from, drink_until, location "
+        "FROM wines WHERE quantity > 0"
+    ).fetchall()
+
+    ready, too_young, past_peak, unknown = [], [], [], []
+    entering = leaving = 0
+    for r in rows:
+        frm, until = r["drink_from"], r["drink_until"]
+        if frm is None and until is None:
+            unknown.append(r)
+            continue
+        if frm == current_year:
+            entering += 1
+        if until == current_year:
+            leaving += 1
+        if frm is not None and current_year < frm:
+            too_young.append(r)
+        elif until is not None and current_year > until:
+            past_peak.append(r)
+        else:
+            ready.append(r)
+
+    ready.sort(key=lambda r: r["drink_until"] if r["drink_until"] is not None else _FAR_YEAR)
+    too_young.sort(key=lambda r: r["drink_from"] if r["drink_from"] is not None else _FAR_YEAR)
+    past_peak.sort(key=lambda r: r["drink_until"] if r["drink_until"] is not None else _FAR_YEAR)
+    unknown.sort(key=lambda r: (r["name"] or "").lower())
+
+    return {
+        "current_year": current_year,
+        "ready_now": len(ready),
+        "entering_this_year": entering,
+        "leaving_this_year": leaving,
+        "counts": {
+            "ready": len(ready),
+            "too_young": len(too_young),
+            "past_peak": len(past_peak),
+            "unknown": len(unknown),
+        },
+        "ready": [_dw_entry(r) for r in ready],
+        "too_young": [_dw_entry(r) for r in too_young],
+        "past_peak": [_dw_entry(r) for r in past_peak],
+        "unknown": [_dw_entry(r) for r in unknown],
+    }

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -1,11 +1,14 @@
 import json
 import os
+import re
 import secrets
 import shutil
 import sqlite3
+import unicodedata
 import uuid
 from collections import defaultdict
 from datetime import date, datetime
+from difflib import SequenceMatcher
 from flask import Flask, render_template, request, redirect, url_for, send_from_directory, jsonify, g, session, Response
 from werkzeug.security import generate_password_hash, check_password_hash
 from translations import TRANSLATIONS
@@ -752,10 +755,63 @@ def index():
     )
 
 
-def _find_duplicate_wine(db, name, year, bottle_format):
-    """Return the most-recent wine matching name (trimmed, case-insensitive),
-    year, and bottle_format -- regardless of quantity -- or None."""
-    return db.execute(
+def _normalize_duplicate_name(value):
+    """Normalize AI/user label text enough for duplicate-name comparison."""
+    folded = unicodedata.normalize("NFKD", value or "")
+    ascii_text = folded.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", ascii_text.lower())).strip()
+
+
+def _duplicate_name_tokens(value):
+    return tuple(_normalize_duplicate_name(value).split())
+
+
+def _is_contextual_name_variant(left_name, right_name, context_values):
+    """Return True when one wine name is the other plus region/grape/type text."""
+    left = _duplicate_name_tokens(left_name)
+    right = _duplicate_name_tokens(right_name)
+    if not left or not right:
+        return False
+
+    shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+    if len(shorter) < 2 or tuple(longer[:len(shorter)]) != shorter:
+        return False
+
+    suffix = longer[len(shorter):]
+    if not suffix:
+        return True
+
+    context_tokens = set()
+    for value in context_values:
+        context_tokens.update(_duplicate_name_tokens(value))
+    return bool(context_tokens) and set(suffix).issubset(context_tokens)
+
+
+def _is_fuzzy_duplicate_name(left_name, right_name, context_values=()):
+    left_norm = _normalize_duplicate_name(left_name)
+    right_norm = _normalize_duplicate_name(right_name)
+    if not left_norm or not right_norm:
+        return False
+    if left_norm == right_norm:
+        return True
+    if _is_contextual_name_variant(left_name, right_name, context_values):
+        return True
+
+    left_tokens = _duplicate_name_tokens(left_name)
+    right_tokens = _duplicate_name_tokens(right_name)
+    if not left_tokens or not right_tokens or left_tokens[0] != right_tokens[0]:
+        return False
+
+    return SequenceMatcher(None, left_norm, right_norm).ratio() >= 0.92
+
+
+def _find_duplicate_wine(db, name, year, bottle_format, region=None, grape=None, wine_type=None):
+    """Return the most-recent wine matching name, year, and bottle_format.
+
+    Exact name matches are case-insensitive. A conservative fuzzy fallback catches
+    AI label variants such as appending the same region to the wine name.
+    """
+    exact = db.execute(
         """SELECT id, name, year, bottle_format, quantity, location
            FROM wines
            WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
@@ -765,6 +821,25 @@ def _find_duplicate_wine(db, name, year, bottle_format):
            LIMIT 1""",
         (name, year, bottle_format),
     ).fetchone()
+    if exact:
+        return exact
+
+    submitted_context = (region, grape, wine_type)
+    candidates = db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location, region, grape, type
+           FROM wines
+           WHERE year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC""",
+        (year, bottle_format),
+    ).fetchall()
+    for candidate in candidates:
+        context_values = submitted_context + (
+            candidate["region"], candidate["grape"], candidate["type"],
+        )
+        if _is_fuzzy_duplicate_name(name, candidate["name"], context_values):
+            return candidate
+    return None
 
 
 @app.route("/add", methods=["POST"])
@@ -802,7 +877,15 @@ def add():
 
     # -- Phase one: unless the user already chose "separate", look for a dup --
     if dup_action != "separate":
-        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        existing = _find_duplicate_wine(
+            db,
+            name,
+            year,
+            bottle_format,
+            request.form.get("region"),
+            request.form.get("grape"),
+            request.form.get("type"),
+        )
         if existing:
             return jsonify({"ok": False, "duplicate": {
                 "id": existing["id"],

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -16,6 +16,7 @@ from export_import import (
     build_export_zip, export_filename,
     parse_import_file, match_wines, apply_import, ImportError as WineImportError,
 )
+import api_queries
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", secrets.token_hex(32))
@@ -143,7 +144,7 @@ def _ssl_verify():
         return True
 
 
-APP_VERSION = "1.11.0"
+APP_VERSION = "1.12.0"
 
 HA_OPTIONS = load_options()
 
@@ -3145,6 +3146,35 @@ def api_summary():
         for r in rows
     ]
     return jsonify({"total_bottles": total, "by_type": by_type})
+
+
+@app.route("/api/stats")
+def api_stats():
+    db = get_db()
+    data = api_queries.compute_stats(db, datetime.now().year)
+    data["currency"] = HA_OPTIONS.get("currency", "CHF")
+    return jsonify(ok=True, **data)
+
+
+@app.route("/api/drink-window")
+def api_drink_window():
+    db = get_db()
+    return jsonify(ok=True, **api_queries.compute_drink_window(db, datetime.now().year))
+
+
+@app.route("/api/wines")
+def api_wines_list():
+    db = get_db()
+    return jsonify(ok=True, **api_queries.query_wines(db, request.args))
+
+
+@app.route("/api/wines/<int:wine_id>")
+def api_wines_detail(wine_id):
+    db = get_db()
+    row = db.execute("SELECT * FROM wines WHERE id = ?", (wine_id,)).fetchone()
+    if not row:
+        return jsonify(ok=False, error="not_found"), 404
+    return jsonify(ok=True, wine=api_queries.serialize_wine(row, full=True))
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -143,7 +143,7 @@ def _ssl_verify():
         return True
 
 
-APP_VERSION = "1.10.0"
+APP_VERSION = "1.11.0"
 
 HA_OPTIONS = load_options()
 

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -752,9 +752,68 @@ def index():
     )
 
 
+def _find_duplicate_wine(db, name, year, bottle_format):
+    """Return the most-recent wine matching name (trimmed, case-insensitive),
+    year, and bottle_format -- regardless of quantity -- or None."""
+    return db.execute(
+        """SELECT id, name, year, bottle_format, quantity, location
+           FROM wines
+           WHERE TRIM(name) = TRIM(?) COLLATE NOCASE
+             AND year IS ?
+             AND bottle_format = ?
+           ORDER BY id DESC
+           LIMIT 1""",
+        (name, year, bottle_format),
+    ).fetchone()
+
+
 @app.route("/add", methods=["POST"])
 def add():
     db = get_db()
+    dup_action = request.form.get("dup_action", "").strip()
+
+    # Normalize the same values the matcher and INSERT use.
+    name = request.form["name"].strip()
+    year = request.form.get("year") or None
+    bottle_format_raw = request.form.get("bottle_format", "").strip()
+    bottle_format = float(bottle_format_raw) if bottle_format_raw else 0.75
+    qty = int(request.form.get("quantity", 1))
+
+    # -- Merge: bump an existing wine's quantity, log a restock --
+    if dup_action == "merge":
+        target_id = request.form.get("dup_target_id", "").strip()
+        target = db.execute(
+            "SELECT id, quantity FROM wines WHERE id=?", (target_id,)
+        ).fetchone() if target_id else None
+        if not target:
+            return jsonify({"ok": False, "error": "merge_target_missing"}), 400
+        db.execute(
+            "UPDATE wines SET quantity = quantity + ? WHERE id=?",
+            (qty, target["id"]),
+        )
+        db.execute(
+            "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
+            (target["id"], "restocked", qty, datetime.now().isoformat()),
+        )
+        db.commit()
+        if is_ajax():
+            return jsonify({"ok": True, "wine": wine_json(target["id"]), "stats": stats_json()})
+        return redirect(g.get("ingress", "") + url_for("index"))
+
+    # -- Phase one: unless the user already chose "separate", look for a dup --
+    if dup_action != "separate":
+        existing = _find_duplicate_wine(db, name, year, bottle_format)
+        if existing:
+            return jsonify({"ok": False, "duplicate": {
+                "id": existing["id"],
+                "name": existing["name"],
+                "year": existing["year"],
+                "bottle_format": existing["bottle_format"],
+                "quantity": existing["quantity"],
+                "location": existing["location"],
+            }})
+
+    # -- Insert (no match, or user chose "separate") --
     image = save_image(request.files.get("image"))
     # If no new image uploaded but AI already saved one, use that
     if not image:
@@ -763,7 +822,6 @@ def add():
             image = ai_img
     price_raw = request.form.get("price", "").strip()
     vivino_raw = request.form.get("vivino_id", "").strip()
-    bottle_format_raw = request.form.get("bottle_format", "").strip()
     maturity_data_raw = request.form.get("maturity_data", "").strip() or None
     taste_profile_raw = request.form.get("taste_profile", "").strip() or None
     food_pairings_raw = request.form.get("food_pairings", "").strip() or None
@@ -774,11 +832,11 @@ def add():
             maturity_data, taste_profile, food_pairings)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
-            request.form["name"].strip(),
-            request.form.get("year") or None,
+            name,
+            year,
             request.form.get("type"),
             request.form.get("region", "").strip(),
-            int(request.form.get("quantity", 1)),
+            qty,
             int(request.form.get("rating", 0)),
             request.form.get("notes", "").strip(),
             image,
@@ -790,7 +848,7 @@ def add():
             request.form.get("location", "").strip() or None,
             request.form.get("grape", "").strip() or None,
             int(vivino_raw) if vivino_raw else None,
-            float(bottle_format_raw) if bottle_format_raw else 0.75,
+            bottle_format,
             maturity_data_raw,
             taste_profile_raw,
             food_pairings_raw,
@@ -798,8 +856,6 @@ def add():
     )
     db.commit()
     new_id = cur.lastrowid
-    # Log the addition
-    qty = int(request.form.get("quantity", 1))
     db.execute(
         "INSERT INTO timeline (wine_id, action, quantity, timestamp) VALUES (?,?,?,?)",
         (new_id, "added", qty, datetime.now().isoformat()),

--- a/wine-tracker/app/app.py
+++ b/wine-tracker/app/app.py
@@ -3138,7 +3138,13 @@ def api_summary():
         "SELECT type, COUNT(*) as cnt, SUM(quantity) as total FROM wines GROUP BY type"
     ).fetchall()
     total = db.execute("SELECT SUM(quantity) FROM wines WHERE quantity > 0").fetchone()[0] or 0
-    return jsonify({"total_bottles": total, "by_type": [dict(r) for r in rows]})
+    # Expose English wine-type labels so HA sensors read the same regardless of UI language.
+    en = TRANSLATIONS["en"]
+    by_type = [
+        {**dict(r), "type": en.get(f"wine_type_{r['type']}", r["type"])}
+        for r in rows
+    ]
+    return jsonify({"total_bottles": total, "by_type": by_type})
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/wine-tracker/app/static/style.css
+++ b/wine-tracker/app/static/style.css
@@ -802,6 +802,16 @@ html.light .filter-option:hover { background: rgba(0,0,0,.05); }
 /* Duplicate modal */
 .dup-hint { font-size: .82rem; color: var(--muted); background: var(--bg);
             border-radius: 8px; padding: .75rem; line-height: 1.5; }
+.duplicate-detect-overlay { z-index: 260; }
+.duplicate-detect-modal { max-width: 380px; }
+.duplicate-detect-actions {
+  flex-direction: column;
+  gap: 8px;
+}
+.duplicate-detect-actions .btn-submit,
+.duplicate-detect-actions .btn-cancel {
+  width: 100%;
+}
 
 /* ── Form Elements ─────────────────────────────────────────────────────────── */
 label { font-size: .8rem; color: var(--muted); display: block; margin-bottom: .25rem; }

--- a/wine-tracker/app/templates/_wine_edit_modal.html
+++ b/wine-tracker/app/templates/_wine_edit_modal.html
@@ -833,17 +833,34 @@ function reloadViaVivino() {
 // Uses a callback pattern: if window._onWineSaved is defined, call it;
 // otherwise reload the page.
 
+var _dupPendingForm = null;
+var _dupPending = null;
+
 document.getElementById('wineForm').addEventListener('submit', function(e) {
   e.preventDefault();
   var form = this;
+  submitWineForm(form, null);
+});
+
+function submitWineForm(form, dupAction, targetId) {
   var fd = new FormData(form);
+  if (dupAction) {
+    fd.set('dup_action', dupAction);
+    if (targetId != null) fd.set('dup_target_id', targetId);
+  }
   fetch(form.action, {
     method: 'POST', body: fd,
     headers: { 'X-Requested-With': 'XMLHttpRequest' }
   })
   .then(function(r) { return r.json(); })
   .then(function(data) {
+    // Duplicate detected on an /add submit -> ask the user.
+    if (!data.ok && data.duplicate) {
+      showDupDetectDialog(form, data.duplicate);
+      return;
+    }
     if (!data.ok) return;
+    closeModal('dupDetectModal');
     closeModal('wineModal');
     if (typeof window._onWineSaved === 'function') {
       window._onWineSaved(data);
@@ -851,7 +868,36 @@ document.getElementById('wineForm').addEventListener('submit', function(e) {
       window.location.reload();
     }
   });
-});
+}
+
+function showDupDetectDialog(form, dup) {
+  _dupPendingForm = form;
+  _dupPending = dup;
+  var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
+  var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
+  var body = (window.T.dup_detect_body || '')
+    .replace('{qty}', dup.quantity)
+    .replace('{name}', dup.name || '')
+    .replace('{year}', dup.year || '')
+    .replace('{format}', fmt)
+    .replace('{location}', dup.location || '-');
+  document.getElementById('dupDetectBody').textContent = body;
+  document.getElementById('dupMergeBtn').textContent =
+    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  openModal('dupDetectModal');
+}
+
+function dupMerge() {
+  if (_dupPendingForm && _dupPending) {
+    submitWineForm(_dupPendingForm, 'merge', _dupPending.id);
+  }
+}
+
+function dupSeparate() {
+  if (_dupPendingForm) {
+    submitWineForm(_dupPendingForm, 'separate');
+  }
+}
 
 // ── Modal overlay / ESC handling for wineModal ──────────────────────────────
 // Other pages set up generic overlay click handlers; we need the wineModal-specific

--- a/wine-tracker/app/templates/_wine_edit_modal.html
+++ b/wine-tracker/app/templates/_wine_edit_modal.html
@@ -150,6 +150,25 @@
   </div>
 </div>
 
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay duplicate-detect-overlay" id="dupDetectModal">
+  <div class="modal duplicate-detect-modal">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="cancelDupDetectDialog()">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions duplicate-detect-actions">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()"></button>
+      <button class="btn-cancel" onclick="dupSeparate()">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="cancelDupDetectDialog()">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
+
 <script src="{{ ingress }}/static/wine-modal.js"></script>
 <script>
 // ── Wine Edit Modal JS ──────────────────────────────────────────────────────
@@ -860,6 +879,7 @@ function submitWineForm(form, dupAction, targetId) {
       return;
     }
     if (!data.ok) return;
+    resetDupDetectDialog();
     closeModal('dupDetectModal');
     closeModal('wineModal');
     if (typeof window._onWineSaved === 'function') {
@@ -873,6 +893,9 @@ function submitWineForm(form, dupAction, targetId) {
 function showDupDetectDialog(form, dup) {
   _dupPendingForm = form;
   _dupPending = dup;
+  var bodyEl = document.getElementById('dupDetectBody');
+  var mergeBtn = document.getElementById('dupMergeBtn');
+  if (!bodyEl || !mergeBtn) return;
   var addedQty = parseInt(new FormData(form).get('quantity') || '1', 10) || 1;
   var fmt = String(dup.bottle_format != null ? dup.bottle_format : '');
   var body = (window.T.dup_detect_body || '')
@@ -881,10 +904,19 @@ function showDupDetectDialog(form, dup) {
     .replace('{year}', dup.year || '')
     .replace('{format}', fmt)
     .replace('{location}', dup.location || '-');
-  document.getElementById('dupDetectBody').textContent = body;
-  document.getElementById('dupMergeBtn').textContent =
-    (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
+  bodyEl.textContent = body;
+  mergeBtn.textContent = (window.T.dup_detect_merge || '').replace('{n}', dup.quantity + addedQty);
   openModal('dupDetectModal');
+}
+
+function resetDupDetectDialog() {
+  _dupPendingForm = null;
+  _dupPending = null;
+}
+
+function cancelDupDetectDialog() {
+  resetDupDetectDialog();
+  closeModal('dupDetectModal');
 }
 
 function dupMerge() {

--- a/wine-tracker/app/templates/index.html
+++ b/wine-tracker/app/templates/index.html
@@ -226,6 +226,24 @@
   </div>
 </div>
 
+<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
+<div class="modal-overlay" id="dupDetectModal">
+  <div class="modal" style="max-width:380px">
+    <div class="modal-header">
+      {{ t.dup_detect_title }}
+      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
+    </div>
+    <div class="delete-confirm-body">
+      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
+      <div class="delete-confirm-msg" id="dupDetectBody"></div>
+    </div>
+    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
+      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
+      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
+      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
+    </div>
+  </div>
+</div>
 
 <!-- ═══════════════ WINE VIEW MODAL ═══════════════ -->
 {% include '_wine_view_modal.html' %}

--- a/wine-tracker/app/templates/index.html
+++ b/wine-tracker/app/templates/index.html
@@ -226,25 +226,6 @@
   </div>
 </div>
 
-<!-- ═══════════════ DUPLICATE-DETECT MODAL ═══════════════ -->
-<div class="modal-overlay" id="dupDetectModal">
-  <div class="modal" style="max-width:380px">
-    <div class="modal-header">
-      {{ t.dup_detect_title }}
-      <button class="modal-close" onclick="closeModal('dupDetectModal')">×</button>
-    </div>
-    <div class="delete-confirm-body">
-      <div class="delete-confirm-icon"><i class="mdi mdi-bottle-wine"></i></div>
-      <div class="delete-confirm-msg" id="dupDetectBody"></div>
-    </div>
-    <div class="delete-confirm-actions" style="flex-direction:column; gap:8px">
-      <button class="btn-submit" id="dupMergeBtn" onclick="dupMerge()" style="width:100%"></button>
-      <button class="btn-cancel" onclick="dupSeparate()" style="width:100%">{{ t.dup_detect_separate }}</button>
-      <button class="btn-cancel" onclick="closeModal('dupDetectModal')" style="width:100%">{{ t.dup_detect_cancel }}</button>
-    </div>
-  </div>
-</div>
-
 <!-- ═══════════════ WINE VIEW MODAL ═══════════════ -->
 {% include '_wine_view_modal.html' %}
 {% include '_wine_view_extras.html' %}

--- a/wine-tracker/app/translations.py
+++ b/wine-tracker/app/translations.py
@@ -207,6 +207,13 @@ TRANSLATIONS = {
     "dup_hint": "Alle anderen Felder (Typ, Region, Bewertung, Notizen, Foto) werden übernommen.",
     "btn_create_dup": "Duplikat anlegen",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Wein bereits vorhanden",
+    "dup_detect_body": "Du hast bereits {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Zum vorhandenen hinzufügen (jetzt {n})",
+    "dup_detect_separate": "Als separaten Eintrag hinzufügen",
+    "dup_detect_cancel": "Abbrechen",
+
     # Empty states
     "empty_no_wines": "Noch keine Weine erfasst.",
     "empty_add_first": "Füge deinen ersten Wein hinzu!",
@@ -554,6 +561,13 @@ TRANSLATIONS = {
     "dup_hint": "All other fields (type, region, rating, notes, photo) will be copied.",
     "btn_create_dup": "Create duplicate",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Wine already in cellar",
+    "dup_detect_body": "You already have {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Add to existing (now {n})",
+    "dup_detect_separate": "Add as separate entry",
+    "dup_detect_cancel": "Cancel",
+
     "empty_no_wines": "No wines recorded yet.",
     "empty_add_first": "Add your first wine!",
     "empty_no_results": "No wines found.",
@@ -896,6 +910,13 @@ TRANSLATIONS = {
     "dup_qty": "Quantité",
     "dup_hint": "Tous les autres champs (type, région, note, notes, photo) seront copiés.",
     "btn_create_dup": "Créer le duplicata",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Vin déjà en cave",
+    "dup_detect_body": "Vous avez déjà {qty}x {name} {year} ({format}l) dans {location}.",
+    "dup_detect_merge": "Ajouter à l'existant (désormais {n})",
+    "dup_detect_separate": "Ajouter comme entrée séparée",
+    "dup_detect_cancel": "Annuler",
 
     "empty_no_wines": "Aucun vin enregistré.",
     "empty_add_first": "Ajoutez votre premier vin !",
@@ -1240,6 +1261,13 @@ TRANSLATIONS = {
     "dup_hint": "Tutti gli altri campi (tipo, regione, valutazione, note, foto) verranno copiati.",
     "btn_create_dup": "Crea duplicato",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Vino già in cantina",
+    "dup_detect_body": "Hai già {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aggiungi all'esistente (ora {n})",
+    "dup_detect_separate": "Aggiungi come voce separata",
+    "dup_detect_cancel": "Annulla",
+
     "empty_no_wines": "Nessun vino registrato.",
     "empty_add_first": "Aggiungi il tuo primo vino!",
     "empty_no_results": "Nessun vino trovato.",
@@ -1582,6 +1610,13 @@ TRANSLATIONS = {
     "dup_qty": "Cantidad",
     "dup_hint": "Todos los demás campos (tipo, región, valoración, notas, foto) se copiarán.",
     "btn_create_dup": "Crear duplicado",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Vino ya en la bodega",
+    "dup_detect_body": "Ya tienes {qty}x {name} {year} ({format}l) en {location}.",
+    "dup_detect_merge": "Añadir al existente (ahora {n})",
+    "dup_detect_separate": "Añadir como entrada separada",
+    "dup_detect_cancel": "Cancelar",
 
     "empty_no_wines": "No hay vinos registrados.",
     "empty_add_first": "¡Añade tu primer vino!",
@@ -1926,6 +1961,13 @@ TRANSLATIONS = {
     "dup_hint": "Todos os outros campos (tipo, região, avaliação, notas, foto) serão copiados.",
     "btn_create_dup": "Criar duplicata",
 
+    # Duplicate detection modal
+    "dup_detect_title": "Vinho já na adega",
+    "dup_detect_body": "Você já tem {qty}x {name} {year} ({format}l) em {location}.",
+    "dup_detect_merge": "Adicionar ao existente (agora {n})",
+    "dup_detect_separate": "Adicionar como entrada separada",
+    "dup_detect_cancel": "Cancelar",
+
     "empty_no_wines": "Nenhum vinho registrado.",
     "empty_add_first": "Adicione seu primeiro vinho!",
     "empty_no_results": "Nenhum vinho encontrado.",
@@ -2268,6 +2310,13 @@ TRANSLATIONS = {
     "dup_qty": "Aantal",
     "dup_hint": "Alle andere velden (type, regio, beoordeling, notities, foto) worden gekopieerd.",
     "btn_create_dup": "Duplicaat maken",
+
+    # Duplicate detection modal
+    "dup_detect_title": "Wijn al in kelder",
+    "dup_detect_body": "Je hebt al {qty}x {name} {year} ({format}l) in {location}.",
+    "dup_detect_merge": "Aan bestaande toevoegen (nu {n})",
+    "dup_detect_separate": "Als aparte vermelding toevoegen",
+    "dup_detect_cancel": "Annuleren",
 
     "empty_no_wines": "Nog geen wijnen geregistreerd.",
     "empty_add_first": "Voeg je eerste wijn toe!",

--- a/wine-tracker/config.yaml
+++ b/wine-tracker/config.yaml
@@ -1,6 +1,6 @@
 name: "Wine Tracker"
 description: "Track and manage your wine cellar"
-version: "1.11.0"
+version: "1.12.0"
 slug: "wine_tracker"
 url: "https://github.com/ofer8/ha-wine-tracker"
 init: false

--- a/wine-tracker/config.yaml
+++ b/wine-tracker/config.yaml
@@ -1,6 +1,6 @@
 name: "Wine Tracker"
 description: "Track and manage your wine cellar"
-version: "1.10.0"
+version: "1.11.0"
 slug: "wine_tracker"
 url: "https://github.com/ofer8/ha-wine-tracker"
 init: false

--- a/wine-tracker/config.yaml
+++ b/wine-tracker/config.yaml
@@ -2,7 +2,7 @@ name: "Wine Tracker"
 description: "Track and manage your wine cellar"
 version: "1.10.0"
 slug: "wine_tracker"
-url: "https://github.com/xenofex7/ha-wine-tracker"
+url: "https://github.com/ofer8/ha-wine-tracker"
 init: false
 arch:
   - aarch64

--- a/wine-tracker/tests/test_api_ha.py
+++ b/wine-tracker/tests/test_api_ha.py
@@ -1,0 +1,342 @@
+"""Tests for the read-only Home Assistant REST API (api_queries + routes)."""
+import json
+
+import api_queries
+
+
+# ── shared insert helper ───────────────────────────────────────────────────────
+_WINE_DEFAULTS = {
+    "name": "Wine", "year": None, "type": None, "region": None,
+    "quantity": 1, "rating": 0, "notes": None, "image": None,
+    "added": "2026-01-01", "purchased_at": None, "price": None,
+    "drink_from": None, "drink_until": None, "location": None,
+    "grape": None, "vivino_id": None, "bottle_format": 0.75,
+    "maturity_data": None, "taste_profile": None, "food_pairings": None,
+}
+
+
+def _insert(db, **fields):
+    """Insert one wines row, commit, return its id. Unspecified columns use defaults."""
+    cols = dict(_WINE_DEFAULTS)
+    cols.update(fields)
+    names = ",".join(cols)
+    placeholders = ",".join("?" * len(cols))
+    cur = db.execute(f"INSERT INTO wines ({names}) VALUES ({placeholders})", tuple(cols.values()))
+    db.commit()
+    return cur.lastrowid
+
+
+def _get_row(db, wine_id):
+    return db.execute("SELECT * FROM wines WHERE id = ?", (wine_id,)).fetchone()
+
+
+# ── type_en ─────────────────────────────────────────────────────────────────────
+def test_type_en_translates_known_keys():
+    assert api_queries.type_en("Rotwein") == "Red Wine"
+    assert api_queries.type_en("Weisswein") == "White Wine"
+    assert api_queries.type_en("Anderes") == "Other"
+
+
+def test_type_en_passes_through_unknown_and_none():
+    assert api_queries.type_en("Glühwein") == "Glühwein"
+    assert api_queries.type_en(None) is None
+    assert api_queries.type_en("") == ""
+
+
+# ── resolve_type_filter ─────────────────────────────────────────────────────────
+def test_resolve_type_filter_maps_english_to_key():
+    assert api_queries.resolve_type_filter("Red Wine") == "Rotwein"
+    assert api_queries.resolve_type_filter("red wine") == "Rotwein"   # case-insensitive
+    assert api_queries.resolve_type_filter("Other") == "Anderes"
+
+
+def test_resolve_type_filter_passthrough_unknown():
+    assert api_queries.resolve_type_filter("Rotwein") == "Rotwein"    # raw key still works
+    assert api_queries.resolve_type_filter("Foo") == "Foo"
+    assert api_queries.resolve_type_filter(None) is None
+
+
+# ── serialize_wine ──────────────────────────────────────────────────────────────
+def test_serialize_wine_light_omits_ai_blobs(db):
+    wid = _insert(db, name="A", type="Rotwein", image="x.jpg",
+                  maturity_data='{"k": 1}', taste_profile='{"body": 2}',
+                  food_pairings='["cheese"]')
+    out = api_queries.serialize_wine(_get_row(db, wid), full=False)
+    assert out["type"] == "Red Wine"
+    assert out["image_path"] == "/uploads/x.jpg"
+    assert "maturity_data" not in out
+    assert "taste_profile" not in out
+    assert "food_pairings" not in out
+
+
+def test_serialize_wine_full_parses_ai_blobs(db):
+    wid = _insert(db, name="A", type="Weisswein",
+                  maturity_data='{"k": 1}', food_pairings='["cheese"]')
+    out = api_queries.serialize_wine(_get_row(db, wid), full=True)
+    assert out["type"] == "White Wine"
+    assert out["maturity_data"] == {"k": 1}        # parsed to object, not string
+    assert out["food_pairings"] == ["cheese"]
+    assert out["taste_profile"] is None        # unset AI field stays None in full mode
+
+
+def test_serialize_wine_full_malformed_json_becomes_none(db):
+    wid = _insert(db, name="A", maturity_data="{not valid json")
+    out = api_queries.serialize_wine(_get_row(db, wid), full=True)
+    assert out["maturity_data"] is None
+
+
+def test_serialize_wine_image_path_none_when_no_image(db):
+    wid = _insert(db, name="A", image=None)
+    out = api_queries.serialize_wine(_get_row(db, wid))
+    assert out["image_path"] is None
+
+
+# ── compute_stats / /api/stats ──────────────────────────────────────────────────
+def test_stats_empty_db(client):
+    resp = client.get("/api/stats")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert data["total_bottles"] == 0
+    assert data["distinct_wines"] == 0
+    assert data["by_type"] == []
+    assert data["by_region"] == []
+    assert data["currency"] == "CHF"
+
+
+def test_stats_aggregates(db):
+    _insert(db, name="A", type="Rotwein", region="Bordeaux", grape="Merlot",
+            quantity=2, price=10.0, year=2018, bottle_format=0.75, rating=4)
+    _insert(db, name="B", type="Rotwein", region="Bordeaux", grape="Merlot",
+            quantity=3, price=20.0, year=2012, bottle_format=1.5, rating=2)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["total_bottles"] == 5
+    assert s["distinct_wines"] == 2
+    assert s["total_liters"] == round(2 * 0.75 + 3 * 1.5, 2)   # 6.0
+    assert s["total_value"] == round(2 * 10.0 + 3 * 20.0, 2)   # 80.0
+    assert s["avg_age"] == round(((2026 - 2018) + (2026 - 2012)) / 2, 1)  # 11.0
+    assert s["avg_rating"] == 3.0
+    assert s["avg_price"] == round((10.0 + 20.0) / 2, 2)   # 15.0 — wine-row-weighted, mirrors /stats page
+
+
+def test_stats_by_type_uses_english(db):
+    _insert(db, name="A", type="Rotwein", quantity=2)
+    _insert(db, name="B", type="Weisswein", quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    types = {row["type"]: row["bottles"] for row in s["by_type"]}
+    assert types == {"Red Wine": 2, "White Wine": 1}
+
+
+def test_stats_excludes_empty_dimensions(db):
+    _insert(db, name="A", type=None, region="", grape=None, quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["by_type"] == []
+    assert s["by_region"] == []
+    assert s["by_grape"] == []
+
+
+def test_stats_by_decade(db):
+    _insert(db, name="A", year=2018, quantity=1)
+    _insert(db, name="B", year=2012, quantity=2)
+    _insert(db, name="C", year=2003, quantity=1)
+    s = api_queries.compute_stats(db, 2026)
+    decades = {row["decade"]: row["bottles"] for row in s["by_decade"]}
+    assert decades == {2010: 3, 2000: 1}
+
+
+def test_stats_out_of_stock(db):
+    _insert(db, name="A", quantity=0)
+    _insert(db, name="B", quantity=2)
+    s = api_queries.compute_stats(db, 2026)
+    assert s["out_of_stock"] == 1
+    assert s["total_bottles"] == 2
+
+
+# ── compute_drink_window / /api/drink-window ────────────────────────────────────
+def test_drink_window_buckets_both_bounds(db):
+    _insert(db, name="Ready", type="Rotwein", quantity=1, drink_from=2022, drink_until=2028)
+    _insert(db, name="Young", quantity=1, drink_from=2030, drink_until=2035)
+    _insert(db, name="Past", quantity=1, drink_from=2010, drink_until=2020)
+    _insert(db, name="Unknown", quantity=1)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["counts"] == {"ready": 1, "too_young": 1, "past_peak": 1, "unknown": 1}
+    assert dw["ready_now"] == 1
+    assert dw["ready"][0]["name"] == "Ready"
+    assert dw["ready"][0]["type"] == "Red Wine"        # English label
+    assert dw["too_young"][0]["name"] == "Young"
+    assert dw["past_peak"][0]["name"] == "Past"
+    assert dw["unknown"][0]["name"] == "Unknown"
+
+
+def test_drink_window_one_sided_bounds(db):
+    _insert(db, name="OnlyFromReady", quantity=1, drink_from=2025, drink_until=None)
+    _insert(db, name="OnlyFromYoung", quantity=1, drink_from=2030, drink_until=None)
+    _insert(db, name="OnlyUntilReady", quantity=1, drink_from=None, drink_until=2026)
+    _insert(db, name="OnlyUntilPast", quantity=1, drink_from=None, drink_until=2020)
+    dw = api_queries.compute_drink_window(db, 2026)
+    names = lambda bucket: {e["name"] for e in dw[bucket]}
+    assert names("ready") == {"OnlyFromReady", "OnlyUntilReady"}
+    assert names("too_young") == {"OnlyFromYoung"}
+    assert names("past_peak") == {"OnlyUntilPast"}
+
+
+def test_drink_window_entering_and_leaving(db):
+    _insert(db, name="Entering", quantity=1, drink_from=2026, drink_until=2030)
+    _insert(db, name="Leaving", quantity=1, drink_from=2020, drink_until=2026)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["entering_this_year"] == 1
+    assert dw["leaving_this_year"] == 1
+
+
+def test_drink_window_same_year_entering_and_leaving(db):
+    # A one-year window (drink_from == drink_until == current year) is both
+    # entering and leaving this year, and is ready now.
+    _insert(db, name="OneYear", quantity=1, drink_from=2026, drink_until=2026)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["entering_this_year"] == 1
+    assert dw["leaving_this_year"] == 1
+    assert dw["counts"]["ready"] == 1
+    assert dw["ready"][0]["name"] == "OneYear"
+
+
+def test_drink_window_excludes_out_of_stock(db):
+    _insert(db, name="Empty", quantity=0, drink_from=2022, drink_until=2028)
+    dw = api_queries.compute_drink_window(db, 2026)
+    assert dw["counts"] == {"ready": 0, "too_young": 0, "past_peak": 0, "unknown": 0}
+
+
+def test_drink_window_route(client, db):
+    _insert(db, name="Ready", quantity=1, drink_from=2022, drink_until=2028)
+    resp = client.get("/api/drink-window")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert "current_year" in data
+    assert set(data["counts"]) == {"ready", "too_young", "past_peak", "unknown"}
+    assert "ready_now" in data
+    assert "entering_this_year" in data
+    assert "leaving_this_year" in data
+
+
+# ── query_wines / /api/wines ────────────────────────────────────────────────────
+def test_wines_list_light_projection(client, db):
+    _insert(db, name="A", type="Rotwein", image="a.jpg", maturity_data='{"k":1}',
+            taste_profile='{"b":2}', food_pairings='["x"]')
+    resp = client.get("/api/wines")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    assert data["count"] == 1
+    assert data["returned"] == 1
+    w = data["wines"][0]
+    assert w["type"] == "Red Wine"
+    assert w["image_path"] == "/uploads/a.jpg"
+    assert "maturity_data" not in w
+    assert "taste_profile" not in w
+    assert "food_pairings" not in w
+
+
+def test_wines_filter_type_english(client, db):
+    _insert(db, name="Red", type="Rotwein")
+    _insert(db, name="White", type="Weisswein")
+    resp = client.get("/api/wines?type=Red Wine")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "Red"
+
+
+def test_wines_filter_region_substring(client, db):
+    _insert(db, name="A", region="Bordeaux, FR")
+    _insert(db, name="B", region="Tuscany, IT")
+    resp = client.get("/api/wines?region=Bordeaux")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "A"
+
+
+def test_wines_filter_grape_year_rating(client, db):
+    _insert(db, name="A", grape="Merlot", year=2018, rating=5)
+    _insert(db, name="B", grape="Syrah", year=2020, rating=2)
+    assert json.loads(client.get("/api/wines?grape=Merlot").data)["count"] == 1
+    assert json.loads(client.get("/api/wines?year=2020").data)["count"] == 1
+    assert json.loads(client.get("/api/wines?min_rating=3").data)["count"] == 1
+
+
+def test_wines_filter_in_stock(client, db):
+    _insert(db, name="Full", quantity=2)
+    _insert(db, name="Empty", quantity=0)
+    resp = client.get("/api/wines?in_stock=true")
+    data = json.loads(resp.data)
+    assert data["count"] == 1
+    assert data["wines"][0]["name"] == "Full"
+
+
+def test_wines_sort_year_desc(client, db):
+    _insert(db, name="Old", year=2018)
+    _insert(db, name="New", year=2020)
+    resp = client.get("/api/wines?sort=year&order=desc")
+    data = json.loads(resp.data)
+    assert [w["year"] for w in data["wines"]] == [2020, 2018]
+
+
+def test_wines_invalid_sort_falls_back(client, db):
+    _insert(db, name="A")
+    resp = client.get("/api/wines?sort=banana&order=sideways")
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data["ok"] is True
+
+
+def test_wines_pagination(client, db):
+    for i in range(3):
+        _insert(db, name=f"W{i}")
+    resp = client.get("/api/wines?limit=2")
+    data = json.loads(resp.data)
+    assert data["count"] == 3
+    assert data["returned"] == 2
+    assert len(data["wines"]) == 2
+
+
+def test_wines_pagination_offset(client, db):
+    for i in range(3):
+        _insert(db, name=f"W{i}")
+    # default name sort asc -> W0, W1, W2; offset=1 limit=2 -> W1, W2
+    resp = client.get("/api/wines?sort=name&order=asc&limit=2&offset=1")
+    data = json.loads(resp.data)
+    assert data["count"] == 3            # total before pagination
+    assert data["returned"] == 2
+    assert [w["name"] for w in data["wines"]] == ["W1", "W2"]
+
+
+# ── /api/wines/<id> detail ──────────────────────────────────────────────────────
+def test_wine_detail_full_record(client, db):
+    wid = _insert(db, name="A", type="Rotwein", image="a.jpg",
+                  maturity_data='{"k": 1}', food_pairings='["cheese"]')
+    resp = client.get(f"/api/wines/{wid}")
+    data = json.loads(resp.data)
+    assert data["ok"] is True
+    w = data["wine"]
+    assert w["type"] == "Red Wine"
+    assert w["image_path"] == "/uploads/a.jpg"
+    assert w["maturity_data"] == {"k": 1}        # parsed, present in detail
+    assert w["food_pairings"] == ["cheese"]
+
+
+def test_wine_detail_not_found(client):
+    resp = client.get("/api/wines/999999")
+    data = json.loads(resp.data)
+    assert resp.status_code == 404
+    assert data["ok"] is False
+    assert data["error"] == "not_found"
+
+
+# ── auth gate (mirrors test_api.py auth pattern) ────────────────────────────────
+def test_api_requires_auth_when_enabled():
+    import app as wine_app
+    wine_app.init_db()
+    wine_app.AUTH_ENABLED = True
+    try:
+        c = wine_app.app.test_client()
+        assert c.get("/api/stats").status_code == 401
+        assert c.get("/api/wines").status_code == 401
+        assert c.get("/api/drink-window").status_code == 401
+        assert c.get("/api/wines/1").status_code == 401
+    finally:
+        wine_app.AUTH_ENABLED = False

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -103,7 +103,7 @@ class TestIndex:
         """Settings modal should contain About section with app version."""
         resp = client.get("/")
         html = resp.data.decode()
-        assert "v1.11.0" in html
+        assert "v1.12.0" in html
         assert "settings_about" in html or "Über" in html
 
     def test_view_modal_present(self, client):

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -103,7 +103,7 @@ class TestIndex:
         """Settings modal should contain About section with app version."""
         resp = client.get("/")
         html = resp.data.decode()
-        assert "v1.10.0" in html
+        assert "v1.11.0" in html
         assert "settings_about" in html or "Über" in html
 
     def test_view_modal_present(self, client):

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -111,6 +111,13 @@ class TestIndex:
         resp = client.get("/")
         assert b'id="viewModal"' in resp.data
 
+    def test_duplicate_detect_modal_present_once(self, client):
+        """Duplicate-detect dialog belongs to the shared add/edit modal stack."""
+        resp = client.get("/")
+        html = resp.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
+        assert 'duplicate-detect-overlay' in html
+
     def test_card_body_calls_view(self, client, sample_wine):
         """Card body onclick should call viewFromCard."""
         resp = client.get("/")
@@ -561,6 +568,7 @@ class TestStatsPage:
         html = resp.data.decode()
         assert 'id="wineModal"' in html
         assert 'id="wineForm"' in html
+        assert html.count('id="dupDetectModal"') == 1
 
     def test_stats_stock_chart_with_timeline(self, client, sample_wine, db):
         """Stats page should include stock chart data when timeline entries exist."""
@@ -681,6 +689,11 @@ class TestTimelinePage:
         resp = client.get("/timeline")
         assert resp.status_code == 200
         assert b"timeline" in resp.data.lower() or b"Zeitverlauf" in resp.data
+
+    def test_timeline_has_duplicate_detect_modal(self, client):
+        resp = client.get("/timeline")
+        html = resp.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
 
 
 # ── Wine log integration ─────────────────────────────────────────────────────
@@ -821,6 +834,19 @@ class TestChatPage:
         assert "openViewModal" in html
         assert "/api/wine/" in html
         assert 'id="viewModal"' in html
+
+    @patch("app.load_options")
+    def test_chat_has_duplicate_detect_modal(self, mock_opts, client):
+        mock_opts.return_value = {
+            "currency": "CHF", "language": "en",
+            "ai_provider": "anthropic", "anthropic_api_key": "sk-test",
+            "anthropic_model": "claude-sonnet-4-20250514",
+            "openai_api_key": "", "openrouter_api_key": "",
+            "ollama_host": "", "ollama_model": "",
+        }
+        response = client.get("/chat")
+        html = response.data.decode()
+        assert html.count('id="dupDetectModal"') == 1
 
     @patch("app.load_options")
     def test_chat_new_button_closes_history_sidebar_on_mobile(self, mock_opts, client):
@@ -1245,6 +1271,49 @@ def test_add_match_is_case_and_whitespace_insensitive(client, db):
     _add_wine(client, name="Château Test", quantity="1")
     resp = _add_wine(client, name="  château test ", quantity="1")
     assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_contextual_ai_name_variant_returns_duplicate(client, db):
+    _add_wine(
+        client,
+        name="Raeburn Pinot Noir",
+        year="2023",
+        region="Sonoma County, California",
+        grape="Pinot Noir",
+        quantity="1",
+    )
+    resp = _add_wine(
+        client,
+        name="Raeburn Pinot Noir Sonoma County",
+        year="2023",
+        region="Sonoma County, California",
+        grape="Pinot Noir",
+        quantity="6",
+    )
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Raeburn Pinot Noir"
+    assert body["duplicate"]["quantity"] == 1
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_prefix_with_non_context_suffix_is_not_a_match(client, db):
+    _add_wine(
+        client,
+        name="Château Test",
+        year="2018",
+        region="Bordeaux, FR",
+        quantity="1",
+    )
+    resp = _add_wine(
+        client,
+        name="Château Test Reserve",
+        year="2018",
+        region="Bordeaux, FR",
+        quantity="1",
+    )
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
 
 
 def test_add_different_year_is_not_a_match(client, db):

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -671,7 +671,8 @@ class TestApiSummary:
         data = json.loads(resp.data)
         assert data["total_bottles"] == 3
         assert len(data["by_type"]) == 1
-        assert data["by_type"][0]["type"] == "Rotwein"
+        # by_type uses English labels for HA sensors, regardless of UI language
+        assert data["by_type"][0]["type"] == "Red Wine"
 
     def test_multiple_types(self, client):
         client.post("/add", data={"name": "Red", "type": "Rotwein", "quantity": "2"}, headers=AJAX)
@@ -680,6 +681,8 @@ class TestApiSummary:
         data = json.loads(resp.data)
         assert data["total_bottles"] == 5
         assert len(data["by_type"]) == 2
+        types = {row["type"] for row in data["by_type"]}
+        assert types == {"Red Wine", "White Wine"}
 
 
 # ── GET /timeline ─────────────────────────────────────────────────────────────

--- a/wine-tracker/tests/test_routes.py
+++ b/wine-tracker/tests/test_routes.py
@@ -1183,3 +1183,105 @@ class TestDevAuth:
         resp = client.get("/", follow_redirects=False)
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
+
+
+# ── Duplicate detection on /add ───────────────────────────────────────────────
+
+def _add_wine(client, **overrides):
+    data = {
+        "name": "Château Test", "year": "2018", "type": "Rotwein",
+        "region": "Bordeaux, FR", "quantity": "1", "rating": "0",
+        "bottle_format": "0.75",
+    }
+    data.update(overrides)
+    return client.post("/add", data=data,
+                       headers={"X-Requested-With": "XMLHttpRequest"})
+
+
+def test_add_no_existing_inserts_normally(client, db):
+    resp = _add_wine(client, quantity="2")
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    rows = db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()
+    assert rows["c"] == 1
+
+
+def test_add_matching_wine_returns_duplicate_without_inserting(client, db):
+    _add_wine(client, quantity="3")
+    resp = _add_wine(client, quantity="1")
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert body["duplicate"]["name"] == "Château Test"
+    assert body["duplicate"]["year"] == 2018
+    assert body["duplicate"]["quantity"] == 3
+    # Still only ONE row — phase one must not insert
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_bumps_quantity_and_logs_restock(client, db):
+    first = json.loads(_add_wine(client, quantity="3").data)
+    target_id = first["wine"]["id"]
+    resp = _add_wine(client, quantity="2", dup_action="merge",
+                     dup_target_id=str(target_id))
+    body = json.loads(resp.data)
+    assert body["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 5
+    restock = db.execute(
+        "SELECT quantity FROM timeline WHERE wine_id=? AND action='restocked'",
+        (target_id,)).fetchone()
+    assert restock["quantity"] == 2
+
+
+def test_add_separate_inserts_second_row(client, db):
+    _add_wine(client, quantity="1")
+    resp = _add_wine(client, quantity="1", dup_action="separate")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_match_is_case_and_whitespace_insensitive(client, db):
+    _add_wine(client, name="Château Test", quantity="1")
+    resp = _add_wine(client, name="  château test ", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+
+
+def test_add_different_year_is_not_a_match(client, db):
+    _add_wine(client, year="2018", quantity="1")
+    resp = _add_wine(client, year="2019", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_different_bottle_format_is_not_a_match(client, db):
+    _add_wine(client, bottle_format="0.75", quantity="1")
+    resp = _add_wine(client, bottle_format="1.5", quantity="1")
+    assert json.loads(resp.data)["ok"] is True
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 2
+
+
+def test_add_null_vintage_wines_match(client, db):
+    _add_wine(client, year="", quantity="1")
+    resp = _add_wine(client, year="", quantity="1")
+    assert json.loads(resp.data)["ok"] is False
+    assert db.execute("SELECT COUNT(*) AS c FROM wines").fetchone()["c"] == 1
+
+
+def test_add_merge_restocks_empty_bottle(client, db):
+    first = json.loads(_add_wine(client, quantity="1").data)
+    target_id = first["wine"]["id"]
+    db.execute("UPDATE wines SET quantity=0 WHERE id=?", (target_id,))
+    db.commit()
+    _add_wine(client, quantity="2", dup_action="merge", dup_target_id=str(target_id))
+    qty = db.execute("SELECT quantity FROM wines WHERE id=?", (target_id,)).fetchone()["quantity"]
+    assert qty == 2
+
+
+def test_translations_have_dup_detect_keys():
+    import translations
+    keys = ["dup_detect_title", "dup_detect_body", "dup_detect_merge",
+            "dup_detect_separate", "dup_detect_cancel"]
+    for lang, d in translations.TRANSLATIONS.items():
+        for k in keys:
+            assert k in d, f"{lang} missing {k}"


### PR DESCRIPTION
## Summary

Adds a duplicate-detection flow for wine entries so users can choose whether a newly added wine should update an existing matching bottle or be saved as a separate entry.

## What changed

- Detects likely duplicate wines during the add-wine flow.
- Adds a confirmation path to either merge/restock the existing wine or create a separate entry.
- Fixes the duplicate restock flow from the edit modal so restocks update the intended existing wine.
- Adds localized duplicate-detection dialog text across supported languages.
- Adds route coverage for duplicate detection, merge/restock behavior, and separate-entry handling.
- Adds a small Docker Compose setup for local development.

## Notes

The main behavior change is the new deduplication workflow around adding and restocking wines. The Docker Compose files are included only to make local development easier.